### PR TITLE
transform sparse arrays into metadata and a tuple of 1D arrays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,19 @@ license = "MIT"
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
+[project.optional-dependencies]
+pydata-sparse = ["sparse>=0.17.0"]
+scipy-sparse = ["scipy>=1.15.3"]
+torch-sparse = ["torch>=2.7.0"]
+
+[dependency-groups]
+dev = [
+  "black>=25.1.0",
+  "ipython>=9.2.0",
+  "pytest>=8.3.5",
+  "pytest-xdist>=3.6.1",
+]
+
 [tool.hatch]
 version.source = "vcs"
 

--- a/zarr_sparse/sparse.py
+++ b/zarr_sparse/sparse.py
@@ -1,0 +1,70 @@
+from functools import singledispatch
+
+
+@singledispatch
+def extract_arrays(x):
+    """convert a sparse array into metadata and arrays
+
+    Parameters
+    ----------
+    x
+        The sparse array.
+
+    Returns
+    -------
+    metadata : dict
+        A description of the sparse array, including the kind.
+    arrays : tuple of array-like
+        The arrays the sparse array consists of.
+    """
+    raise NotImplementedError(f"unknown array type: {type(x)}")
+
+
+try:
+    import sparse
+
+    @extract_arrays.register(sparse.COO)
+    def _(x):
+        metadata = {
+            "sparse-kind": x.format,
+            "fill_value": x.fill_value,
+            "shape": x.shape,
+        }
+        arrays = (x.data, *x.coords)
+
+        return metadata, arrays
+
+    @extract_arrays.register(sparse.GCXS)
+    def _(x):
+        metadata = {
+            "sparse-kind": x.format,
+            "fill_value": x.fill_value,
+            "compressed_axes": x.compressed_axes,
+            "shape": x.shape,
+        }
+        arrays = (x.data, x.indices, x.indptr)
+        return metadata, arrays
+
+except ImportError:
+    pass
+
+
+try:
+    import scipy.sparse
+
+    @extract_arrays.register(scipy.sparse.coo_array)
+    def _(x):
+        metadata = {"sparse-kind": x.format, "fill_value": 0, "shape": x.shape}
+        arrays = x.data, *x.coords
+
+        return metadata, arrays
+
+    @extract_arrays.register(scipy.sparse.coo_matrix)
+    def _(x):
+        metadata = {"sparse-kind": x.format, "fill_value": 0, "shape": x.shape}
+        arrays = x.data, *x.coords
+
+        return metadata, arrays
+
+except ImportError:
+    pass

--- a/zarr_sparse/tests/__init__.py
+++ b/zarr_sparse/tests/__init__.py
@@ -1,0 +1,32 @@
+import pytest
+
+try:
+    import sparse  # noqa: F401
+
+    has_pydata_sparse = True
+except ImportError:
+    has_pydata_sparse = False
+
+requires_pydata_sparse = pytest.mark.skipif(
+    not has_pydata_sparse, reason="pydata sparse is not available"
+)
+
+try:
+    import scipy  # noqa: F401
+
+    has_scipy = True
+except ImportError:
+    has_scipy = False
+
+requires_scipy = pytest.mark.skipif(not has_scipy, reason="scipy is not available")
+
+try:
+    import torch.sparse  # noqa: F401
+
+    has_pytorch = True
+except ImportError:
+    has_pytorch = False
+
+requires_pytorch = pytest.mark.skipif(
+    not has_pytorch, reason="pytorch is not available"
+)

--- a/zarr_sparse/tests/test_extract_arrays.py
+++ b/zarr_sparse/tests/test_extract_arrays.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from zarr_sparse.sparse import extract_arrays
+from zarr_sparse.tests import requires_pydata_sparse, requires_scipy
+
+
+@requires_pydata_sparse
+@requires_scipy
+def test_roundtrip():
+    import sparse
+
+    x = sparse.COO(
+        np.array([[0, 4, 6], [35, 53, 61]]), np.arange(3), shape=(10, 100), fill_value=0
+    )
+
+    y = x.to_scipy_sparse()
+
+    metadata_x, (data_x, rows_x, cols_x) = extract_arrays(x)
+    metadata_y, (data_y, rows_y, cols_y) = extract_arrays(y)
+
+    assert metadata_x == metadata_y
+    np.testing.assert_equal(data_x, data_y)
+    np.testing.assert_equal(rows_x, rows_y)
+    np.testing.assert_equal(cols_x, cols_y)


### PR DESCRIPTION
In order to be able to write the sparse arrays to disk we need to first split them into metadata and a tuple of 1D arrays.

We also want to be able to serialize multiple sparse array implementations (at least pydata-`sparse`, `scipy.sparse`, and `torch.sparse` with at least `COO` and `CSR` / `CSC`).

This PR adds a `singledispatch` function with naive try-except import guards that defines the conversions. No real tests yet.