### PR TITLE
sparse array codec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: ${{ matrix.os }} py${{ matrix.python-version }}
+    runs-on: "${{ matrix.os }}"
+
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # grab all branches and tags
+
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install Hatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Set Up Hatch Env
+        run: |
+          hatch env create 'test.py${{ matrix.python-version }}'
+          hatch env run -e 'test.py${{ matrix.python-version }}' list-env
+
+      - name: Run Tests
+        run: |
+          hatch env run -e 'test.py${{ matrix.python-version }}' tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.12", "3.13"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ torch-sparse = ["torch>=2.7.0"]
 [dependency-groups]
 dev = [
   "black>=25.1.0",
+  "hypothesis>=6.138.0",
   "ipdb>=0.13.13",
   "ipython>=9.2.0",
   "pytest>=8.3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,21 @@ version.source = "vcs"
 [tool.hatch.build]
 hooks.vcs.version-file = "zarr_sparse/_version.py"
 
+[tool.hatch.envs.test]
+dependencies = [
+  "sparse",
+  "numpy",
+  "zarr-python",
+]
+features = ["test"]
+
+[tool.hatch.envs.test.matrix]
+python = ["3.12", "3.13"]
+
+[tool.hatch.envs.test.scripts]
+list-env = "pip list"
+tests = "pytest -n auto"
+
 [tool.ruff]
 target-version = "py311"
 builtins = ["ellipsis"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ build-backend = "hatchling.build"
 pydata-sparse = ["sparse>=0.17.0"]
 scipy-sparse = ["scipy>=1.15.3"]
 torch-sparse = ["torch>=2.7.0"]
+test = [
+  "pytest",
+  "pytest-xdist",
+  "hypothesis",
+]
 
 [dependency-groups]
 dev = [
@@ -39,7 +44,7 @@ hooks.vcs.version-file = "zarr_sparse/_version.py"
 dependencies = [
   "sparse",
   "numpy",
-  "zarr-python",
+  "zarr",
 ]
 features = ["test"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ ignore = [
   "E402",
   "E501",
   "E731",
+  "UP038",
 ]
 select = [
   "F",   # Pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ test = [
 [dependency-groups]
 dev = [
   "black>=25.1.0",
+  "hatch>=1.14.1",
   "hypothesis>=6.138.0",
   "ipdb>=0.13.13",
   "ipython>=9.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ description = "Codec-based encoding for sparse arrays"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+  "sparse",
   "zarr>=3.0.8",
 ]
 dynamic = ["version"]
@@ -70,3 +71,7 @@ fixable = ["I", "TID252"]
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.
 ban-relative-imports = "all"
+
+[tool.uv.sources]
+zarr = { path = "../zarr-python", editable = true }
+sparse = { path = "../../sparse", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 ]
 features = ["test"]
 
-[tool.hatch.envs.test.matrix]
+[[tool.hatch.envs.test.matrix]]
 python = ["3.12", "3.13"]
 
 [tool.hatch.envs.test.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ torch-sparse = ["torch>=2.7.0"]
 [dependency-groups]
 dev = [
   "black>=25.1.0",
+  "ipdb>=0.13.13",
   "ipython>=9.2.0",
   "pytest>=8.3.5",
   "pytest-xdist>=3.6.1",

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -25,6 +25,9 @@ def normalize_slice(slice_, size):
 
 def _decompose_slice_by_chunks(slice_, offsets, chunksizes):
     def _decompose_slice(slice_, offset, size):
+        if slice_ == slice(None):
+            return normalize_slice(slice_, size)
+
         if (slice_.start < offset and slice_.stop <= offset) or (
             slice_.start >= offset + size
         ):
@@ -43,7 +46,9 @@ def _decompose_slice_by_chunks(slice_, offsets, chunksizes):
     }
 
     return {
-        index: slice_ for index, slice_ in decomposed.items() if slice_size(slice_) > 0
+        index: slice_
+        for index, slice_ in decomposed.items()
+        if slice_size(slice_, chunksizes[index]) > 0
     }
 
 

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -58,7 +58,7 @@ def _decompose_int_by_chunks(indexer, offsets, chunksizes):
 
 
 def _decompose_array_by_chunks(indexer, offsets, chunksizes):
-    pass
+    raise NotImplementedError
 
 
 def decompose_by_chunks(indexer, chunks):

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -25,7 +25,6 @@ class ChunkGrid:
     """Chunk grid that records slice assignment"""
 
     def __init__(self, *, shape, dtype, order, fill_value):
-        print("setting shape to:", shape)
         self._shape = shape
         self._dtype = dtype
         self._order = order  # unused

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -27,7 +27,7 @@ class ChunkGrid:
     def __init__(self, *, shape, dtype, order, fill_value):
         self._shape = shape
         self._dtype = dtype
-        self._order = order  # unused
+        self._order = order  # unused, physical arrays are always 1-d for sparse
         self._fill_value = fill_value
         self._data = {}
 

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -10,17 +10,11 @@ import sparse
 from zarr.core.buffer.core import Buffer, BufferPrototype, NDBuffer
 from zarr.registry import register_ndbuffer
 
+from zarr_sparse.slices import decompose_slices, normalize_slice, slice_size
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Self
-
-
-def slice_size(slice_, size):
-    return len(range(*slice_.indices(size)))
-
-
-def normalize_slice(slice_, size):
-    return slice(*slice_.indices(size))
 
 
 def tiles_by_id(parts):
@@ -86,77 +80,6 @@ def expand_chunks(chunks, shape):
         return chunkspec
 
     return tuple(_expand(chunkspec, size) for chunkspec, size in zip(chunks, shape))
-
-
-def slice_to_chunk_indices(slice_, offsets, chunks):
-    condition = (slice_.start <= offsets) & (slice_.stop >= offsets + chunks)
-    selected = np.flatnonzero(condition)
-
-    if selected.size == 0:
-        raise ValueError(f"Selected chunk out of bounds: {slice_}")
-
-    return tuple(int(_) for _ in selected)
-
-
-def decompose_slice(slice_, offsets, chunks, local=False):
-    chunk_indices = slice_to_chunk_indices(slice_, offsets, chunks)
-    total_size = sum(chunks)
-
-    decomposed = {
-        index: (
-            slice_slice(
-                slice_,
-                slice(int(offsets[index]), int(offsets[index]) + chunks[index], 1),
-                total_size,
-            )
-            if not local
-            else slice(
-                slice_.start - int(offsets[index]),
-                slice_.stop - int(offsets[index]),
-                slice_.step,
-            )
-        )
-        for index in chunk_indices
-    }
-    return list(decomposed.items())
-
-
-def decompose_slices(slices, all_offsets, all_chunks, local=False):
-    decomposed = (
-        decompose_slice(slice_, offsets, chunks, local=local)
-        for slice_, offsets, chunks in zip(slices, all_offsets, all_chunks)
-    )
-    combined = [tuple(zip(*elements)) for elements in itertools.product(*decomposed)]
-    return combined
-
-
-def slice_slice(old_slice: slice, applied_slice: slice, size: int) -> slice:
-    """Given a slice and the size of the dimension to which it will be applied,
-    index it with another slice to return a new slice equivalent to applying
-    the slices sequentially
-    """
-    old_slice = normalize_slice(old_slice, size)
-
-    size_after_old_slice = len(range(old_slice.start, old_slice.stop, old_slice.step))
-    if size_after_old_slice == 0:
-        # nothing left after applying first slice
-        return slice(0)
-
-    applied_slice = normalize_slice(applied_slice, size_after_old_slice)
-
-    start = old_slice.start + applied_slice.start * old_slice.step
-    if start < 0:
-        # nothing left after applying second slice
-        # (can only happen for old_slice.step < 0, e.g. [10::-1], [20:])
-        return slice(0)
-
-    stop = old_slice.start + applied_slice.stop * old_slice.step
-    if stop < 0:
-        stop = None
-
-    step = old_slice.step * applied_slice.step
-
-    return slice(start, stop, step)
 
 
 def sparse_equal(a, b, equal_nan: bool) -> bool:

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -57,8 +57,8 @@ class ChunkGrid:
             chunks = shape
 
         self._chunks = expand_chunks(chunks, shape)
-        self._offsets = tuple(
-            np.cumulative_sum(c, include_initial=True)[:-1] for c in self._chunks
+        self._bounds = tuple(
+            np.cumulative_sum(c, include_initial=True) for c in self._chunks
         )
         grid_shape = tuple(math.ceil(s / max(c)) for s, c in zip(shape, self._chunks))
         self._data = np.full(grid_shape, dtype=object, fill_value=None)
@@ -108,9 +108,7 @@ class ChunkGrid:
             return ValueError("indexing is only supported for slices")
 
         normalized_key = tuple(normalize_slice(k, s) for k, s in zip(key, self.shape))
-        decomposed_slices = decompose_slices(
-            normalized_key, self._offsets, self.chunks, local=True
-        )
+        decomposed_slices = decompose_slices(normalized_key, self._bounds)
         chunk_indices_ = list(c for c, _ in decomposed_slices)
         by_dim = [sorted(set(c)) for c in zip(*chunk_indices_)]
         new_grid_shape = tuple(len(dim) for dim in by_dim)
@@ -156,9 +154,7 @@ class ChunkGrid:
 
         # decompose into selected chunks and slices into the value
         # iterate over selected chunks and assign the value subset
-        decomposed_slices = decompose_slices(
-            normalized_key, self._offsets, self.chunks, local=False
-        )
+        decomposed_slices = decompose_slices(normalized_key, self._bounds)
 
         for chunk_indices, value_slice in decomposed_slices:
             # TODO: fix the bug in `decompose_slice`

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -246,7 +246,7 @@ class SparseNDBuffer(NDBuffer):
         raise NotImplementedError("can't convert to `numpy`")
 
     def as_ndarray_like(self):
-        return self._data.get_value()
+        return self._data
 
     def __getitem__(self, key: Any) -> Self:
         return self.__class__(self._data.__getitem__(key))

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -48,13 +48,13 @@ def _decompose_slice_by_chunks(slice_, offsets, chunksizes):
 
 
 def _decompose_int_by_chunks(indexer, offsets, chunksizes):
-    index = bisect.bisect_right(offsets, indexer)
-    new_indexer = indexer - offsets[index]
-
-    if index == offsets.size - 1 and new_indexer >= chunksizes[index]:
+    if indexer >= offsets[-1] + chunksizes[-1]:
         return {}
-    else:
-        return {index: new_indexer}
+
+    index = bisect.bisect_right(offsets, indexer) - 1
+    new_indexer = indexer - int(offsets[index])
+
+    return {index: new_indexer}
 
 
 def _decompose_array_by_chunks(indexer, offsets, chunksizes):
@@ -63,7 +63,7 @@ def _decompose_array_by_chunks(indexer, offsets, chunksizes):
 
 def decompose_by_chunks(indexer, chunks):
     chunksizes = np.array(chunks, dtype="uint64")
-    offsets = np.cumsum(chunksizes)
+    offsets = np.cumulative_sum(chunksizes, include_initial=True)[:-1]
 
     if isinstance(indexer, slice):
         return _decompose_slice_by_chunks(indexer, offsets, chunksizes)

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+import numpy.typing as npt
+import sparse
+from zarr.core.buffer.core import Buffer, BufferPrototype, NDBuffer
+from zarr.registry import register_ndbuffer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Self
+
+
+@register_ndbuffer
+class SparseNDBuffer(NDBuffer):
+    def __init__(self, sparse_array) -> None:
+        super().__init__(sparse_array)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        shape: Iterable[int],
+        dtype: npt.DTypeLike,
+        order: Literal["C", "F"] = "C",
+        fill_value: Any | None = None,
+    ) -> Self:
+        # np.zeros is much faster than np.full, and therefore using it when possible is better.
+        if fill_value is None or (isinstance(fill_value, int) and fill_value == 0):
+            return cls(sparse.zeros(shape=tuple(shape), dtype=dtype, order=order))
+        else:
+            return cls(
+                sparse.full(
+                    shape=tuple(shape), fill_value=fill_value, dtype=dtype, order=order
+                )
+            )
+
+    @classmethod
+    def from_numpy_array(cls, array_like: npt.ArrayLike) -> Self:
+        return cls.from_ndarray_like(array_like)
+
+    def as_numpy_array(self) -> npt.NDArray[Any]:
+        """Returns the buffer as a NumPy array (host memory).
+
+        Warnings
+        --------
+        Might have to copy data, consider using `.as_ndarray_like()` instead.
+
+        Returns
+        -------
+            NumPy array of this buffer (might be a data copy)
+        """
+        raise NotImplementedError("can't convert to `numpy`")
+
+    def __getitem__(self, key: Any) -> Self:
+        return self.__class__(self._data.__getitem__(key))
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        if isinstance(value, NDBuffer):
+            value = value._data
+        self._data.__setitem__(key, value)
+
+    def all_equal(self, other: Any, equal_nan: bool = True) -> bool:
+        """Compare to `other` using np.array_equal."""
+        if other is None:
+            # Handle None fill_value for Zarr V2
+            return False
+
+        equal_nan = (
+            equal_nan
+            if self._data.dtype.kind not in ("U", "S", "T", "O", "V")
+            else False
+        )
+        if other.ndim == 0:
+            return np.array_equal(
+                self._data.fill_value, other, equal_nan=equal_nan
+            ) and (
+                self._data.nnz == 0
+                or np.equal(
+                    self._data.data,
+                    np.broadcast_to(other, self._data.data.shape),
+                    equal_nan,
+                )
+            )
+
+        # use array_equal to obtain equal_nan=True functionality
+        # Since fill-value is a scalar, isn't there a faster path than allocating a new array for fill value
+        # every single time we have to write data?
+        _data, other = sparse.broadcast_arrays(self._data, other)
+
+        return sparse.equal(
+            self._data,
+            other,
+            equal_nan=(
+                equal_nan
+                if self._data.dtype.kind not in ("U", "S", "T", "O", "V")
+                else False
+            ),
+        )
+
+
+buffer_prototype = BufferPrototype(buffer=Buffer, nd_buffer=SparseNDBuffer)
+
+
+def sparse_buffer_prototype() -> BufferPrototype:
+    return BufferPrototype(buffer=Buffer, nd_buffer=NDBuffer)

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -187,6 +187,14 @@ class ChunkGrid:
 
         return all(sparse_equal(a, b, equal_nan=equal_nan) for a, b in to_compare)
 
+    def get_chunk(self, indexer=None):
+        if indexer is None:
+            if self._data.size != 1:
+                raise ValueError("need to select a chunk for multiple chunk arrays")
+            return self._data.item()
+
+        return self._data[indexer]
+
     def get_value(self):
         return combine_nd(self._data)
 

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import math
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -10,76 +9,13 @@ import sparse
 from zarr.core.buffer.core import Buffer, BufferPrototype, NDBuffer
 from zarr.registry import register_ndbuffer
 
+from zarr_sparse.chunks import expand_chunks
+from zarr_sparse.combine import combine_nd
 from zarr_sparse.slices import decompose_slices, normalize_slice, slice_size
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Self
-
-
-def tiles_by_id(parts):
-    return {
-        np.unravel_index(index, parts.shape): array
-        for index, array in enumerate(parts.flatten())
-    }
-
-
-def until_nth(index):
-    def indexer(val):
-        return val[:index]
-
-    return indexer
-
-
-def as_item_key(key):
-    def wrapper(it):
-        return key(it[0])
-
-    return wrapper
-
-
-def groupby_mapping(mapping, key):
-    wrapped_key = as_item_key(key)
-    raw_groups = itertools.groupby(
-        sorted(mapping.items(), key=wrapped_key), key=wrapped_key
-    )
-    return ((key, (el for _, el in group)) for key, group in raw_groups)
-
-
-def combine_nd(parts):
-    tiles = tiles_by_id(parts)
-    xp = parts.flat[0].__array_namespace__()
-
-    # innermost to outermost
-    for axis in range(parts.ndim - 1, -1, -1):
-        tiles = {
-            key: xp.concat(list(arrays), axis=axis)
-            for key, arrays in groupby_mapping(tiles, key=until_nth(axis))
-        }
-
-    return next(iter(tiles.values()))
-
-
-def expand_chunks(chunks, shape):
-    def _expand(chunkspec, size):
-        if chunkspec == -1:
-            return (size,)
-        elif isinstance(chunkspec, int):
-            n_full_chunks, remainder = divmod(size, chunkspec)
-            chunks = (chunkspec,) * n_full_chunks
-
-            if remainder > 0:
-                chunks += (remainder,)
-
-            return chunks
-
-        chunkspec = tuple(chunkspec)
-        if sum(chunkspec) != size:
-            raise ValueError(f"chunks don't add up to the full size: {chunkspec}")
-
-        return chunkspec
-
-    return tuple(_expand(chunkspec, size) for chunkspec, size in zip(chunks, shape))
 
 
 def sparse_equal(a, b, equal_nan: bool) -> bool:

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -64,15 +64,18 @@ def sparse_equal(a, b, equal_nan: bool) -> bool:
     equal_nan = equal_nan if a.dtype.kind not in ("U", "S", "T", "O", "V") else False
 
     if b.ndim == 0:
-        return np.array_equal(
+        if not np.array_equal(
             a.fill_value, getattr(b, "fill_value", b), equal_nan=equal_nan
-        ) and (
-            a.nnz == 0
-            or np.equal(
-                a.data,
-                np.broadcast_to(b.data, a.data.shape),
-                equal_nan,
-            )
+        ):
+            return False
+
+        if a.nnz == 0:
+            return True
+
+        return np.array_equal(
+            a.data,
+            np.broadcast_to(b.data, a.data.shape),
+            equal_nan=equal_nan,
         )
 
     # use array_equal to obtain equal_nan=True functionality

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -199,7 +199,7 @@ class ChunkGrid:
             fill_value=data.fill_value,
             chunks=None,
         )
-        result._data = data
+        result._data[0, 0] = data
         return result
 
     def __setitem__(self, key, value):
@@ -212,6 +212,8 @@ class ChunkGrid:
         chunk_indices = tuple(
             slice_to_chunk_index(k, o) for k, o in zip(key, self._offsets)
         )
+        if isinstance(value, ChunkGrid):
+            value = value._data.item()
         self._data[chunk_indices] = value
 
     def get_value(self):
@@ -233,7 +235,7 @@ class ChunkGrid:
 
         if other.ndim == 0:
             to_compare = (
-                (c, other._data if isinstance(other, ChunkGrid) else other)
+                (c, other._data.item() if isinstance(other, ChunkGrid) else other)
                 for c in self._data.ravel().tolist()
             )
         else:

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -60,10 +60,8 @@ def slice_to_chunk_indices(slice_, offsets, chunks):
 
 
 def decompose_slice(slice_, offsets, chunks, local=False):
-    print("decompose:", slice_, offsets, chunks)
     chunk_indices = slice_to_chunk_indices(slice_, offsets, chunks)
     total_size = sum(chunks)
-    print(chunk_indices)
 
     decomposed = {
         index: (

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -78,6 +78,63 @@ def decompose_by_chunks(indexer, chunks):
         return _decompose_array_by_chunks(indexer, offsets, chunksizes)
 
 
+def expand_chunks(chunks, shape):
+    def _expand(chunkspec, size):
+        if chunkspec == -1:
+            return (size,)
+        elif isinstance(chunkspec, int):
+            n_full_chunks, remainder = divmod(size, chunkspec)
+            chunks = (chunkspec,) * n_full_chunks
+
+            if remainder > 0:
+                chunks += (remainder,)
+
+            return chunks
+
+        chunkspec = tuple(chunkspec)
+        if sum(chunkspec) != size:
+            raise ValueError(f"chunks don't add up to the full size: {chunkspec}")
+
+        return chunkspec
+
+    return tuple(_expand(chunkspec, size) for chunkspec, size in zip(chunks, shape))
+
+
+def slice_to_chunk_index(slice_, offsets):
+    if slice_ == slice(None):
+        return 0
+
+    chunk_index = np.flatnonzero(offsets == slice_.start)
+
+    if chunk_index.size == 0:
+        raise ValueError(f"Selected chunk out of bounds: {slice_}")
+
+    return chunk_index[0]
+
+
+def sparse_equal(a, b, equal_nan: bool) -> bool:
+    equal_nan = equal_nan if a.dtype.kind not in ("U", "S", "T", "O", "V") else False
+
+    if b.ndim == 0:
+        return np.array_equal(
+            a.fill_value, getattr(b, "fill_value", b), equal_nan=equal_nan
+        ) and (
+            a.nnz == 0
+            or np.equal(
+                a.data,
+                np.broadcast_to(b.data, a.data.shape),
+                equal_nan,
+            )
+        )
+
+    # use array_equal to obtain equal_nan=True functionality
+    # Since fill-value is a scalar, isn't there a faster path than allocating a new array for fill value
+    # every single time we have to write data?
+    _data, other = sparse.broadcast_arrays(a, b)
+
+    return sparse.equal(a, other, equal_nan=equal_nan)
+
+
 class ChunkGrid:
     """Chunk grid that records slice assignment"""
 
@@ -89,15 +146,21 @@ class ChunkGrid:
 
         if chunks is None:
             chunks = shape
-        self._chunks = chunks
 
-        grid_shape = tuple(math.ceil(s / c) for s, c in zip(shape, chunks))
+        self._chunks = expand_chunks(chunks, shape)
+        self._offsets = tuple(
+            np.cumulative_sum(c, include_initial=True)[:-1] for c in self._chunks
+        )
+        grid_shape = tuple(math.ceil(s / max(c)) for s, c in zip(shape, self._chunks))
         self._data = np.full(grid_shape, dtype=object, fill_value=None)
-        self._slices = np.full(grid_shape, dtype=object, fill_value=None)
 
     @property
     def shape(self):
         return self._shape
+
+    @property
+    def ndim(self):
+        return len(self._shape)
 
     @property
     def dtype(self):
@@ -116,12 +179,40 @@ class ChunkGrid:
         return self._chunks
 
     def __getitem__(self, key):
-        normalized_key = tuple(normalize_slice(k, s) for k, s in zip(key, self.shape))
-        return self._data[normalized_key]
+        chunk_indices = tuple(
+            slice_to_chunk_index(k, o) for k, o in zip(key, self._offsets)
+        )
+        data = self._data[chunk_indices]
+        if data is None:
+            chunk_shape = tuple(
+                chunksizes[index]
+                for index, chunksizes in zip(chunk_indices, self.chunks)
+            )
+            data = sparse.full(
+                chunk_shape, fill_value=self.fill_value, dtype=self.dtype
+            )
+
+        result = type(self)(
+            shape=data.shape,
+            dtype=data.dtype,
+            order=self.order,
+            fill_value=data.fill_value,
+            chunks=None,
+        )
+        result._data = data
+        return result
 
     def __setitem__(self, key, value):
-        normalized_key = tuple(normalize_slice(k, s) for k, s in zip(key, self.shape))
-        self._data[normalized_key] = value
+        if any(
+            s == slice(None) and size != total_size
+            for s, size, total_size in zip(key, value.shape, self.shape)
+        ):
+            raise ValueError("size mismatch")
+
+        chunk_indices = tuple(
+            slice_to_chunk_index(k, o) for k, o in zip(key, self._offsets)
+        )
+        self._data[chunk_indices] = value
 
     def get_value(self):
         chunk_sizes = [
@@ -130,10 +221,32 @@ class ChunkGrid:
         ]
         return chunk_sizes
 
+    def all_equal(self, other: Any, equal_nan: bool) -> bool:
+        if other.ndim != 0 and (
+            self.shape != other.shape
+            or self.dtype != other.dtype
+            or self.order != other.order
+            or self.fill_value != other.fill_value
+            or self.chunks != other.chunks
+        ):
+            return False
+
+        if other.ndim == 0:
+            to_compare = (
+                (c, other._data if isinstance(other, ChunkGrid) else other)
+                for c in self._data.ravel().tolist()
+            )
+        else:
+            to_compare = zip(self._data.ravel().tolist(), other._data.ravel().tolist())
+
+        return all(sparse_equal(a, b, equal_nan=equal_nan) for a, b in to_compare)
+
 
 @register_ndbuffer
 class SparseNDBuffer(NDBuffer):
     def __init__(self, chunk_grid) -> None:
+        if chunk_grid is None:
+            raise ValueError("chunk grid is `None`")
         self._data = chunk_grid
 
     @classmethod
@@ -144,10 +257,15 @@ class SparseNDBuffer(NDBuffer):
         dtype: npt.DTypeLike,
         order: Literal["C", "F"] = "C",
         fill_value: Any | None = None,
+        chunks=None,
     ) -> Self:
         return cls(
             ChunkGrid(
-                shape=tuple(shape), dtype=dtype, order=order, fill_value=fill_value
+                shape=tuple(shape),
+                dtype=dtype,
+                order=order,
+                fill_value=fill_value,
+                chunks=chunks,
             )
         )
 
@@ -156,12 +274,13 @@ class SparseNDBuffer(NDBuffer):
         return cls.from_ndarray_like(array_like)
 
     @classmethod
-    def from_ndarray_like(cls, ndarray_like) -> Self:
+    def from_ndarray_like(cls, ndarray_like, chunks=None) -> Self:
         buffer = cls.create(
             shape=ndarray_like.shape,
             dtype=ndarray_like.dtype,
             order="C",
             fill_value=ndarray_like.fill_value,
+            chunks=chunks or getattr(ndarray_like, "chunks", None),
         )
         buffer[(slice(None),) * ndarray_like.ndim] = ndarray_like
 
@@ -205,37 +324,7 @@ class SparseNDBuffer(NDBuffer):
             # Handle None fill_value for Zarr V2
             return False
 
-        equal_nan = (
-            equal_nan
-            if self._data.dtype.kind not in ("U", "S", "T", "O", "V")
-            else False
-        )
-        if other.ndim == 0:
-            return np.array_equal(
-                self._data.fill_value, other, equal_nan=equal_nan
-            ) and (
-                self._data.nnz == 0
-                or np.equal(
-                    self._data.data,
-                    np.broadcast_to(other, self._data.data.shape),
-                    equal_nan,
-                )
-            )
-
-        # use array_equal to obtain equal_nan=True functionality
-        # Since fill-value is a scalar, isn't there a faster path than allocating a new array for fill value
-        # every single time we have to write data?
-        _data, other = sparse.broadcast_arrays(self._data, other)
-
-        return sparse.equal(
-            self._data,
-            other,
-            equal_nan=(
-                equal_nan
-                if self._data.dtype.kind not in ("U", "S", "T", "O", "V")
-                else False
-            ),
-        )
+        return self._data.all_equal(other, equal_nan=equal_nan)
 
 
 buffer_prototype = BufferPrototype(buffer=Buffer, nd_buffer=SparseNDBuffer)

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -228,6 +228,22 @@ class ChunkGrid:
     def chunks(self):
         return self._chunks
 
+    def __repr__(self):
+        shape = self.shape
+        fill_value = self.fill_value
+        chunks = self.chunks
+
+        grid = self._data
+
+        repr_ = f"<ChunkGrid({shape=}, {fill_value=}, {chunks=}>"
+
+        return "\n".join(
+            [
+                repr_,
+                repr(grid),
+            ]
+        )
+
     def __getitem__(self, key):
         if any(not isinstance(k, slice) for k in key):
             return ValueError("indexing is only supported for slices")

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -23,8 +23,47 @@ def normalize_slice(slice_, size):
     return slice(*slice_.indices(size))
 
 
+def tiles_by_id(parts):
+    return {
+        np.unravel_index(index, parts.shape): array
+        for index, array in enumerate(parts.flatten())
+    }
+
+
+def until_nth(index):
+    def indexer(val):
+        return val[:index]
+
+    return indexer
+
+
+def as_item_key(key):
+    def wrapper(it):
+        return key(it[0])
+
+    return wrapper
+
+
+def groupby_mapping(mapping, key):
+    wrapped_key = as_item_key(key)
+    raw_groups = itertools.groupby(
+        sorted(mapping.items(), key=wrapped_key), key=wrapped_key
+    )
+    return ((key, (el for _, el in group)) for key, group in raw_groups)
+
+
 def combine_nd(parts):
-    raise NotImplementedError
+    tiles = tiles_by_id(parts)
+    xp = parts.flat[0].__array_namespace__()
+
+    # innermost to outermost
+    for axis in range(parts.ndim - 1, -1, -1):
+        tiles = {
+            key: xp.concat(list(arrays), axis=axis)
+            for key, arrays in groupby_mapping(tiles, key=until_nth(axis))
+        }
+
+    return next(iter(tiles.values()))
 
 
 def expand_chunks(chunks, shape):

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -122,6 +122,14 @@ class SparseNDBuffer(NDBuffer):
     def __setitem__(self, key: Any, value: Any) -> None:
         if isinstance(value, NDBuffer):
             value = value._data
+
+        slice_sizes = tuple(
+            slice_size(slice_, size) for slice_, size in zip(key, self._data.shape)
+        )
+        if value.ndim == 0:
+            # fill value
+            value = sparse.full(slice_sizes, fill_value=value, dtype=value.dtype)
+
         self._data.__setitem__(key, value)
 
     def all_equal(self, other: Any, equal_nan: bool = True) -> bool:

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -22,6 +22,10 @@ def normalize_slice(slice_, size):
     return slice(*slice_.indices(size))
 
 
+def combine_nd(parts):
+    raise NotImplementedError
+
+
 def expand_chunks(chunks, shape):
     def _expand(chunkspec, size):
         if chunkspec == -1:
@@ -160,13 +164,6 @@ class ChunkGrid:
             value = value._data.item()
         self._data[chunk_indices] = value
 
-    def get_value(self):
-        chunk_sizes = [
-            tuple(slice_size(k, s) for k, s in zip(key, self._shape))
-            for key in self._data.keys()
-        ]
-        return chunk_sizes
-
     def all_equal(self, other: Any, equal_nan: bool) -> bool:
         if other.ndim != 0 and (
             self.shape != other.shape
@@ -186,6 +183,9 @@ class ChunkGrid:
             to_compare = zip(self._data.ravel().tolist(), other._data.ravel().tolist())
 
         return all(sparse_equal(a, b, equal_nan=equal_nan) for a, b in to_compare)
+
+    def get_value(self):
+        return combine_nd(self._data)
 
 
 @register_ndbuffer

--- a/zarr_sparse/chunks.py
+++ b/zarr_sparse/chunks.py
@@ -1,0 +1,20 @@
+def expand_chunks(chunks, shape):
+    def _expand(chunkspec, size):
+        if chunkspec == -1:
+            return (size,)
+        elif isinstance(chunkspec, int):
+            n_full_chunks, remainder = divmod(size, chunkspec)
+            chunks = (chunkspec,) * n_full_chunks
+
+            if remainder > 0:
+                chunks += (remainder,)
+
+            return chunks
+
+        chunkspec = tuple(chunkspec)
+        if sum(chunkspec) != size:
+            raise ValueError(f"chunks don't add up to the full size: {chunkspec}")
+
+        return chunkspec
+
+    return tuple(_expand(chunkspec, size) for chunkspec, size in zip(chunks, shape))

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -96,12 +96,13 @@ async def decode_table(
     chunk_data: Buffer, chunk_spec: ArraySpec, codecs: list[Codec]
 ) -> list[dict[str, Any]]:
     pipeline = get_pipeline_class().from_codecs(codecs)
+    nbytes_size = 8
 
-    table_size = (
+    nbytes_table = (
         next(
             iter(
                 await pipeline.decode(
-                    [(chunk_data[:8], create_table_chunk_spec(shape=(1,)))]
+                    [(chunk_data[:nbytes_size], create_table_chunk_spec(shape=(1,)))]
                 )
             )
         )
@@ -114,8 +115,8 @@ async def decode_table(
             await pipeline.decode(
                 [
                     (
-                        chunk_data[8 : 8 + table_size],
-                        create_table_chunk_spec(nbytes=table_size),
+                        chunk_data[nbytes_size : nbytes_size + nbytes_table],
+                        create_table_chunk_spec(nbytes=nbytes_table),
                     )
                 ]
             )
@@ -132,7 +133,7 @@ async def decode_table(
         }
         for index, size in enumerate(sizes)
     ]
-    return metadata
+    return metadata, chunk_data[nbytes_size + nbytes_table :]
 
 
 class SparseArrayCodec(ArrayBytesCodec):

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from zarr.abc.codec import ArrayBytesCodec
+from zarr.core.buffer import Buffer, NDBuffer
+from zarr.core.common import JSON
+from zarr.registry import register_codec
+
+if TYPE_CHECKING:
+    from zarr.core.array_spec import ArraySpec
+
+
+class SparseArrayCodec(ArrayBytesCodec):
+    def to_dict(self) -> dict[str, JSON]:
+        return {"name": "sparse"}
+
+    async def _decode_single(
+        self, chunk_data: NDBuffer, chunk_spec: ArraySpec
+    ) -> Buffer | None:
+        raise NotImplementedError
+
+    async def _encode_single(
+        self, chunk_array: NDBuffer, chunk_spec: ArraySpec
+    ) -> Buffer | None:
+        raise NotImplementedError
+
+
+register_codec("sparse", SparseArrayCodec)

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -2,42 +2,110 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 from zarr.abc.codec import ArrayBytesCodec
-from zarr.core.buffer import Buffer, NDBuffer
+from zarr.buffer.cpu import numpy_buffer_prototype
+from zarr.codecs import BytesCodec, ZstdCodec
+from zarr.codecs.sharding import MAX_UINT_64
+from zarr.core.array_spec import ArrayConfig, ArraySpec
+from zarr.core.buffer import Buffer, NDBuffer, default_buffer_prototype
 from zarr.core.common import JSON
-from zarr.registry import register_codec
+from zarr.core.dtype.npy.int import UInt64
+from zarr.registry import get_pipeline_class, register_codec
+
+from zarr_sparse.sparse import extract_arrays
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from zarr.core.array_spec import ArraySpec
 
 
+async def encode_array(array, chunk_spec, codecs):
+    pipeline = get_pipeline_class().from_codecs(codecs)
+
+    ndbuffer = numpy_buffer_prototype().nd_buffer.from_numpy_array(array)
+    array_bytes = next(iter(await pipeline.encode([(ndbuffer, chunk_spec)])))
+    metadata = {
+        "size": array.size,
+        "dtype": array.dtype,
+        "order": "C",
+    }
+
+    return metadata, array_bytes
+
+
+async def encode_table(metadata, codecs):
+    sizes = np.array([m["size"] for m in metadata], dtype="uint64")
+    chunk_spec = ArraySpec(
+        shape=sizes.shape,
+        dtype=UInt64(endianness="little"),
+        fill_value=MAX_UINT_64,
+        config=ArrayConfig(order="C", write_empty_chunks=False),
+        prototype=default_buffer_prototype(),
+    )
+    ndbuffer = numpy_buffer_prototype().nd_buffer.from_numpy_array(sizes)
+
+    pipeline = get_pipeline_class().from_codecs(codecs)
+    table_bytes = next(iter(await pipeline.encode([(ndbuffer, chunk_spec)])))
+
+    return table_bytes
+
+
 class SparseArrayCodec(ArrayBytesCodec):
+    def __init__(self):
+        self.array_codecs = (BytesCodec(), ZstdCodec())
+        self.table_codecs = (BytesCodec(),)
+
     def to_dict(self) -> dict[str, JSON]:
         return {"name": "sparse"}
 
     async def _decode_single(
         self, chunk_data: NDBuffer, chunk_spec: ArraySpec
     ) -> Buffer | None:
-        raise NotImplementedError
+        raise NotImplementedError(f"chunk data: {chunk_data}, chunk spec: {chunk_spec}")
 
-    async def decode(
-        self,
-        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
-    ) -> Iterable[NDBuffer | None]:
-        raise NotImplementedError
+    # async def decode(
+    #     self,
+    #     chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    # ) -> Iterable[NDBuffer | None]:
+    #     print(list(chunks_and_specs))
+    #     raise NotImplementedError
 
     async def _encode_single(
         self, chunk_array: NDBuffer, chunk_spec: ArraySpec
     ) -> Buffer | None:
-        raise NotImplementedError
+        data = chunk_array._data.get_chunk()
+        if data.nnz == 0 and not chunk_spec.config.write_empty_chunks:
+            return None
 
-    async def encode(
-        self,
-        chunks_and_specs: Iterable[tuple[NDBuffer | None, ArraySpec]],
-    ) -> Iterable[Buffer | None]:
-        raise NotImplementedError
+        metadata, arrays = extract_arrays(data)
+
+        prototype = numpy_buffer_prototype()
+
+        encoded = []
+        array_metadata = []
+        for array in arrays:
+            spec = ArraySpec(
+                shape=array.shape,
+                dtype=array.dtype,
+                fill_value=0,
+                config=chunk_spec.config,
+                prototype=prototype,
+            )
+            metadata, encoded_array = await encode_array(array, spec, self.array_codecs)
+            encoded.append(encoded_array)
+            array_metadata.append(metadata)
+
+        merged_buffer = sum(encoded[1:], start=encoded[0])
+
+        table_buffer = await encode_table(array_metadata, self.table_codecs)
+
+        return table_buffer + merged_buffer
+
+    # async def encode(
+    #     self,
+    #     chunks_and_specs: Iterable[tuple[NDBuffer | None, ArraySpec]],
+    # ) -> Iterable[Buffer | None]:
+    #     raise NotImplementedError
 
 
 register_codec("sparse", SparseArrayCodec)

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -16,6 +16,7 @@ from zarr.core.dtype.npy.int import BaseInt, Int64, UInt64
 from zarr.core.dtype.npy.string import FixedLengthUTF32, VariableLengthUTF8
 from zarr.registry import get_pipeline_class, register_codec
 
+from zarr_sparse.comparison import compare_fill_value
 from zarr_sparse.sparse import assemble_array, extract_arrays, sparse_keys
 
 MAX_INT_64 = np.iinfo(np.int64).max
@@ -358,7 +359,9 @@ class SparseArrayCodec(ArrayBytesCodec):
             return None
 
         sparse_metadata, arrays = extract_arrays(data)
-        if sparse_metadata.pop("fill_value") != chunk_spec.fill_value:
+        if not compare_fill_value(
+            sparse_metadata.pop("fill_value"), chunk_spec.fill_value
+        ):
             raise ValueError(
                 "sparse array fill_value doesn't match the chunk fill value"
             )

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import struct
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Self
 
 import numpy as np
 from zarr.abc.codec import ArrayBytesCodec
 from zarr.buffer.cpu import numpy_buffer_prototype
 from zarr.codecs import BytesCodec, ZstdCodec
-from zarr.codecs.sharding import MAX_UINT_64
 from zarr.core.array_spec import ArrayConfig, ArraySpec
 from zarr.core.buffer import Buffer, NDBuffer
 from zarr.core.common import JSON
-from zarr.core.dtype.npy.int import Int64, UInt64
+from zarr.core.dtype import data_type_registry
+from zarr.core.dtype.npy.int import BaseInt, Int64, UInt64
+from zarr.core.dtype.npy.string import FixedLengthUTF32, VariableLengthUTF8
 from zarr.registry import get_pipeline_class, register_codec
 
-from zarr_sparse.sparse import extract_arrays
+from zarr_sparse.sparse import assemble_array, extract_arrays, sparse_keys
 
 MAX_INT_64 = np.iinfo(np.int64).max
 
@@ -24,23 +27,77 @@ if TYPE_CHECKING:
     from zarr.abc.codec import Codec
 
 
-async def encode_array(array, chunk_spec, codecs):
+# TODO: use vlen-str instead of fixed-len
+column_dtypes = {
+    "sparse-kind": "<U5",
+    "order": "<U1",
+    "nbytes": "uint64",
+    "sizes": "uint64",
+    "compressed_axes": "uint64",
+    "column_names": "<U20",
+}
+
+
+@dataclass
+class ArrayMetadata:
+    nbytes: list[int] = field(default_factory=list)
+    sizes: list[int] = field(default_factory=list)
+    dtypes: list[np.dtype] = field(default_factory=list)
+    order: list[str] = field(default_factory=list)
+
+    def __add__(self, other: Self) -> Self:
+        return type(self)(
+            nbytes=self.nbytes + other.nbytes,
+            sizes=self.sizes + other.sizes,
+            dtypes=self.dtypes + other.dtypes,
+            order=self.order + other.order,
+        )
+
+    @classmethod
+    def from_dict(cls, mapping: dict[str, Any]):
+        translations = {
+            "size": "sizes",
+            "dtype": "dtypes",
+        }
+        kwargs = {
+            translations.get(k, k): v if isinstance(v, list) else [v]
+            for k, v in mapping.items()
+        }
+        return cls(**kwargs)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+async def encode_array(
+    array: np.ndarray, chunk_spec: ArraySpec, codecs: tuple[Codec, ...]
+) -> tuple[ArrayMetadata, Buffer]:
     pipeline = get_pipeline_class().from_codecs(codecs)
 
     ndbuffer = numpy_buffer_prototype().nd_buffer.from_numpy_array(array)
     array_bytes = next(iter(await pipeline.encode([(ndbuffer, chunk_spec)])))
-    metadata = {
-        "size": array.size,
-        "nbytes": len(array_bytes),
-        "dtype": array.dtype,
-        "order": "C",
-    }
+    metadata = ArrayMetadata.from_dict(
+        {
+            "size": array.size,
+            "nbytes": len(array_bytes),
+            "dtype": array.dtype,
+            "order": "C",
+        }
+    )
 
     return metadata, array_bytes
 
 
-def create_table_chunk_spec(*, shape=None, nbytes=None):
-    dtype = UInt64(endianness="little")
+def create_table_chunk_spec(*, shape=None, nbytes=None, dtype=None):
+    if isinstance(dtype, str):
+        dtype = np.dtype(dtype)
+
+    if dtype is None:
+        dtype = UInt64(endianness="little")
+    elif dtype.kind == "U":
+        dtype = FixedLengthUTF32.from_native_dtype(dtype)
+    else:
+        dtype = data_type_registry.match_dtype(dtype)
 
     if (shape is None and nbytes is None) or (shape is not None and nbytes is not None):
         raise ValueError("need to pass either shape or nbytes")
@@ -51,101 +108,173 @@ def create_table_chunk_spec(*, shape=None, nbytes=None):
 
         shape = (size,)
 
+    if isinstance(dtype, BaseInt):
+        fill_value = np.iinfo(dtype.to_native_dtype()).max
+    elif isinstance(dtype, (FixedLengthUTF32, VariableLengthUTF8)):
+        fill_value = ""
+
     return ArraySpec(
         shape=shape,
         dtype=dtype,
-        fill_value=MAX_UINT_64,
+        fill_value=fill_value,
         config=ArrayConfig(order="C", write_empty_chunks=False),
         prototype=numpy_buffer_prototype(),
     )
 
 
-async def encode_table(metadata, codecs):
+async def create_offset_table(buffers, codecs):
+    """pack buffer lengths into a small table
+
+    The format is (with n the number of indexed buffers):
+    1. 8 bytes for the size of the table
+    2. n*8 bytes for the offsets
+    3. n*8 bytes for the lengths of each array
+
+    (no compression, so the two arrays are actually the same length)
+    """
     prototype = numpy_buffer_prototype()
     pipeline = get_pipeline_class().from_codecs(codecs)
 
-    byte_lengths = np.array([m["nbytes"] for m in metadata], dtype="uint64")
-    sizes = np.array([m["size"] for m in metadata], dtype="uint64")
-    size_bytes, byte_length_bytes = await pipeline.encode(
+    byte_lengths = np.array(
+        [len(buffer_) for buffer_ in buffers],
+        dtype="uint64",
+    )
+    offsets = np.cumulative_sum(byte_lengths, include_initial=True)[:-1]
+
+    chunk_spec = create_table_chunk_spec(shape=offsets.shape, dtype=offsets.dtype)
+    data_buffers = await pipeline.encode(
         [
-            (
-                prototype.nd_buffer.from_numpy_array(sizes),
-                create_table_chunk_spec(shape=sizes.shape),
-            ),
-            (
-                prototype.nd_buffer.from_numpy_array(byte_lengths),
-                create_table_chunk_spec(shape=byte_lengths.shape),
-            ),
+            (prototype.nd_buffer.from_numpy_array(offsets), chunk_spec),
+            (prototype.nd_buffer.from_numpy_array(byte_lengths), chunk_spec),
         ]
     )
-    table_bytes = size_bytes + byte_length_bytes
+    data_bytes = sum(data_buffers[1:], start=data_buffers[0])
 
-    table_length = np.array([table_bytes._data.size], dtype="uint64")
-    length_bytes = next(
-        iter(
-            await pipeline.encode(
-                [
-                    (
-                        prototype.nd_buffer.from_numpy_array(table_length),
-                        create_table_chunk_spec(shape=table_length.shape),
-                    )
-                ]
-            )
-        )
+    n_bytes = len(data_bytes)
+    length_bytes = prototype.buffer.from_bytes(struct.pack("<L", n_bytes))
+
+    return length_bytes + data_bytes
+
+
+def slice_next(offset, size):
+    return slice(offset, offset + size)
+
+
+async def decode_offset_table(
+    chunk_data: Buffer, codecs: list[Codec]
+) -> np.ndarray[Any, np.dtype[np.unsignedinteger]]:
+    pipeline = get_pipeline_class().from_codecs(codecs)
+
+    n_prefix_bytes = 4
+    [n_buffer_bytes] = struct.unpack("<L", chunk_data[:n_prefix_bytes].to_bytes())
+    bytes_read = n_prefix_bytes
+
+    dtype = np.dtype("uint64")
+    n_bytes_per_buffer = n_buffer_bytes // 2
+    n_elements = n_bytes_per_buffer // dtype.itemsize
+
+    chunk_spec = create_table_chunk_spec(shape=(n_elements,), dtype=dtype)
+
+    offsets_bytes = chunk_data[slice_next(bytes_read, n_bytes_per_buffer)]
+    bytes_read += n_bytes_per_buffer
+    sizes_bytes = chunk_data[slice_next(bytes_read, n_bytes_per_buffer)]
+    bytes_read += n_bytes_per_buffer
+
+    offset_buffer, sizes_buffer = await pipeline.decode(
+        [
+            (offsets_bytes, chunk_spec),
+            (sizes_bytes, chunk_spec),
+        ]
     )
 
-    full_table = length_bytes + table_bytes
+    return bytes_read, offset_buffer.as_numpy_array(), sizes_buffer.as_numpy_array()
+
+
+async def encode_metadata_table(metadata, codecs):
+    """encode the metadata table to bytes
+
+    The format is:
+    1. offset table (offset + size for each entry)
+    2. array of column names
+    3. data arrays
+
+    Each array is encoded as
+    1. 2 bytes for length
+    2. array data bytes
+    """
+    prototype = numpy_buffer_prototype()
+    pipeline = get_pipeline_class().from_codecs(codecs)
+
+    # dtypes can be reconstructed from the array spec
+    metadata.pop("dtypes", None)
+
+    column_names = np.asarray(
+        list(metadata.keys()), dtype=column_dtypes["column_names"]
+    )
+    values = [np.asarray(v, dtype=column_dtypes[k]) for k, v in metadata.items()]
+    arrays = [column_names] + values
+
+    to_encode = [
+        (
+            prototype.nd_buffer.from_numpy_array(array.copy()),
+            create_table_chunk_spec(shape=array.shape, dtype=array.dtype),
+        )
+        for array in arrays
+    ]
+    column_bytes = await pipeline.encode(to_encode)
+
+    column_size_bytes = [
+        prototype.buffer.from_bytes(struct.pack("<H", array.size)) for array in arrays
+    ]
+
+    table_bytes = [size + data for size, data in zip(column_size_bytes, column_bytes)]
+
+    offset_bytes = await create_offset_table(table_bytes, pipeline)
+    full_table = offset_bytes + sum(table_bytes[1:], start=table_bytes[0])
     return full_table
 
 
-async def decode_table(
-    chunk_data: Buffer, chunk_spec: ArraySpec, codecs: list[Codec]
-) -> list[dict[str, Any]]:
+async def decode_table(chunk_data: Buffer, codecs: list[Codec]) -> list[dict[str, Any]]:
     pipeline = get_pipeline_class().from_codecs(codecs)
-    nbytes_size = 8
 
-    nbytes_table = (
-        next(
-            iter(
-                await pipeline.decode(
-                    [(chunk_data[:nbytes_size], create_table_chunk_spec(shape=(1,)))]
-                )
+    bytes_read, offsets, sizes = await decode_offset_table(chunk_data, codecs)
+
+    header_bytes, *column_bytes = [
+        chunk_data[slice_next(offset, size)]
+        for offset, size in zip(offsets + bytes_read, sizes)
+    ]
+    header_chunk_spec = create_table_chunk_spec(
+        shape=tuple(struct.unpack("<H", header_bytes[:2].to_bytes())),
+        dtype=column_dtypes["column_names"],
+    )
+    column_names = next(
+        iter(
+            await pipeline.decode(
+                [
+                    (header_bytes[2:], header_chunk_spec),
+                ]
             )
         )
-        .as_numpy_array()
-        .item()
-    )
-    nbytes_column = nbytes_table // 2  # two columns
+    ).as_numpy_array()
 
-    sizes_offset = nbytes_size
-    byte_length_offset = nbytes_size + nbytes_column
-
-    sizes, byte_lengths = map(
-        lambda x: x.as_numpy_array(),
-        await pipeline.decode(
-            [
-                (
-                    chunk_data[sizes_offset : sizes_offset + nbytes_column],
-                    create_table_chunk_spec(nbytes=nbytes_column),
-                ),
-                (
-                    chunk_data[byte_length_offset : byte_length_offset + nbytes_column],
-                    create_table_chunk_spec(nbytes=nbytes_column),
-                ),
-            ]
-        ),
-    )
-
-    metadata = [
-        {
-            "size": int(size),
-            "nbytes": int(nbytes),
-            "dtype": chunk_spec.dtype if index == 0 else Int64(endianness="little"),
-            "order": "C",
-        }
-        for index, (size, nbytes) in enumerate(zip(sizes, byte_lengths))
+    chunk_specs = [
+        create_table_chunk_spec(
+            shape=tuple(struct.unpack("<H", buffer_[:2].to_bytes())),
+            dtype=column_dtypes[name],
+        )
+        for name, buffer_ in zip(column_names, column_bytes)
     ]
-    return metadata, chunk_data[nbytes_size + nbytes_table :]
+
+    to_decode = [
+        (buffer_[2:], chunk_spec)
+        for buffer_, chunk_spec in zip(column_bytes, chunk_specs)
+    ]
+    columns = [col.as_numpy_array() for col in await pipeline.decode(to_decode)]
+
+    return {
+        str(name): tuple(col.tolist()) if name != "sparse-kind" else col.item()
+        for name, col in zip(column_names, columns)
+    }
 
 
 class SparseArrayCodec(ArrayBytesCodec):
@@ -159,34 +288,58 @@ class SparseArrayCodec(ArrayBytesCodec):
     async def _decode_single(
         self, chunk_data: Buffer, chunk_spec: ArraySpec
     ) -> Buffer | None:
-        table, chunk_bytes = await decode_table(
-            chunk_data, chunk_spec, self.table_codecs
+        bytes_read, offsets, sizes = await decode_offset_table(
+            chunk_data, self.table_codecs
         )
 
-        offset = 0
-        to_decode = []
-        for index, metadata in enumerate(table):
-            dtype = metadata["dtype"]
-            fill_value = (chunk_spec.fill_value if index == 0 else MAX_INT_64,)
-            chunk_spec = ArraySpec(
-                shape=(metadata["size"],),
-                dtype=dtype,
-                fill_value=fill_value,
-                config=ArrayConfig(order=metadata["order"], write_empty_chunks=False),
-                prototype=numpy_buffer_prototype(),
-            )
-            nbytes = metadata["nbytes"]
-            to_decode.append((chunk_bytes[offset : offset + nbytes], chunk_spec))
+        table_bytes, array_bytes = [
+            chunk_data[slice_next(offset, size)]
+            for offset, size in zip(offsets + bytes_read, sizes)
+        ]
 
-            offset += nbytes
+        metadata = await decode_table(table_bytes, self.table_codecs)
+
+        array_offsets = np.cumulative_sum(
+            np.asarray(metadata["nbytes"], dtype="uint64"), include_initial=True
+        )[:-1]
+
+        sparse_metadata = {n: v for n, v in metadata.items() if n in sparse_keys} | {
+            "fill_value": chunk_spec.fill_value,
+            "shape": chunk_spec.shape,
+        }
+        array_metadata_columns = {
+            n: v for n, v in metadata.items() if n not in sparse_keys
+        } | {"offsets": tuple(array_offsets)}
+        array_metadata = [
+            dict(zip(array_metadata_columns, v))
+            for v in zip(*array_metadata_columns.values())
+        ]
+
+        to_decode = [
+            (
+                array_bytes[slice_next(m["offsets"], m["nbytes"])],
+                ArraySpec(
+                    shape=m["sizes"],
+                    dtype=(
+                        chunk_spec.dtype if index == 0 else Int64(endianness="little")
+                    ),
+                    fill_value=chunk_spec.fill_value if index == 0 else MAX_INT_64,
+                    config=ArrayConfig(
+                        order=m["order"],
+                        write_empty_chunks=chunk_spec.config.write_empty_chunks,
+                    ),
+                    prototype=numpy_buffer_prototype(),
+                ),
+            )
+            for index, m in enumerate(array_metadata)
+        ]
 
         pipeline = get_pipeline_class().from_codecs(self.array_codecs)
         decoded = await pipeline.decode(to_decode)
+        arrays = [buf.as_numpy_array() for buf in decoded]
 
-        arrays = [buffer.as_numpy_array() for buffer in decoded]
-        print(arrays)
-
-        raise NotImplementedError(f"chunk data: {chunk_data}, chunk spec: {chunk_spec}")
+        constructed = assemble_array(sparse_metadata, arrays, library="pydata-sparse")
+        return constructed
 
     # async def decode(
     #     self,
@@ -202,7 +355,13 @@ class SparseArrayCodec(ArrayBytesCodec):
         if data.nnz == 0 and not chunk_spec.config.write_empty_chunks:
             return None
 
-        metadata, arrays = extract_arrays(data)
+        sparse_metadata, arrays = extract_arrays(data)
+        if sparse_metadata.pop("fill_value") != chunk_spec.fill_value:
+            raise ValueError(
+                "sparse array fill_value doesn't match the chunk fill value"
+            )
+        if sparse_metadata.pop("shape") != chunk_spec.shape:
+            raise ValueError("sparse array shape doesn't match the chunk shape")
 
         prototype = numpy_buffer_prototype()
 
@@ -220,11 +379,19 @@ class SparseArrayCodec(ArrayBytesCodec):
             encoded.append(encoded_array)
             array_metadata.append(metadata)
 
-        merged_buffer = sum(encoded[1:], start=encoded[0])
+        metadata = (
+            sum(array_metadata, start=ArrayMetadata()).to_dict() | sparse_metadata
+        )
 
-        table_buffer = await encode_table(array_metadata, self.table_codecs)
+        array_buffer = sum(encoded[1:], start=encoded[0])
 
-        return table_buffer + merged_buffer
+        table_buffer = await encode_metadata_table(metadata, self.table_codecs)
+
+        offset_buffer = await create_offset_table(
+            [table_buffer, array_buffer], self.table_codecs
+        )
+
+        return offset_buffer + table_buffer + array_buffer
 
     # async def encode(
     #     self,

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -10,7 +10,7 @@ from zarr.codecs.sharding import MAX_UINT_64
 from zarr.core.array_spec import ArrayConfig, ArraySpec
 from zarr.core.buffer import Buffer, NDBuffer
 from zarr.core.common import JSON
-from zarr.core.dtype.npy.int import UInt64
+from zarr.core.dtype.npy.int import Int64, UInt64
 from zarr.registry import get_pipeline_class, register_codec
 
 from zarr_sparse.sparse import extract_arrays
@@ -126,9 +126,7 @@ async def decode_table(
     metadata = [
         {
             "size": int(size),
-            "dtype": (
-                chunk_spec.dtype.to_native_dtype() if index == 0 else np.dtype("<i8")
-            ),
+            "dtype": chunk_spec.dtype if index == 0 else Int64(endianness="little"),
             "order": "C",
         }
         for index, size in enumerate(sizes)

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -10,7 +10,7 @@ from zarr.buffer.cpu import numpy_buffer_prototype
 from zarr.codecs import BytesCodec, ZstdCodec
 from zarr.core.array_spec import ArrayConfig, ArraySpec
 from zarr.core.buffer import Buffer, NDBuffer
-from zarr.core.common import JSON
+from zarr.core.common import JSON, parse_named_configuration
 from zarr.core.dtype import data_type_registry
 from zarr.core.dtype.npy.int import BaseInt, Int64, UInt64
 from zarr.core.dtype.npy.string import FixedLengthUTF32, VariableLengthUTF8
@@ -281,6 +281,15 @@ class SparseArrayCodec(ArrayBytesCodec):
     def __init__(self):
         self.array_codecs = (BytesCodec(), ZstdCodec())
         self.table_codecs = (BytesCodec(),)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, JSON]) -> Self:
+        _, configuration_parsed = parse_named_configuration(
+            data, "sparse", require_configuration=False
+        )
+        configuration_parsed = configuration_parsed or {}
+
+        return cls(**configuration_parsed)
 
     def to_dict(self) -> dict[str, JSON]:
         return {"name": "sparse"}

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -341,13 +341,6 @@ class SparseArrayCodec(ArrayBytesCodec):
         constructed = assemble_array(sparse_metadata, arrays, library="pydata-sparse")
         return constructed
 
-    # async def decode(
-    #     self,
-    #     chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
-    # ) -> Iterable[NDBuffer | None]:
-    #     print(list(chunks_and_specs))
-    #     raise NotImplementedError
-
     async def _encode_single(
         self, chunk_array: NDBuffer, chunk_spec: ArraySpec
     ) -> Buffer | None:
@@ -392,12 +385,6 @@ class SparseArrayCodec(ArrayBytesCodec):
         )
 
         return offset_buffer + table_buffer + array_buffer
-
-    # async def encode(
-    #     self,
-    #     chunks_and_specs: Iterable[tuple[NDBuffer | None, ArraySpec]],
-    # ) -> Iterable[Buffer | None]:
-    #     raise NotImplementedError
 
 
 register_codec("sparse", SparseArrayCodec)

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -8,6 +8,8 @@ from zarr.core.common import JSON
 from zarr.registry import register_codec
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from zarr.core.array_spec import ArraySpec
 
 
@@ -20,9 +22,21 @@ class SparseArrayCodec(ArrayBytesCodec):
     ) -> Buffer | None:
         raise NotImplementedError
 
+    async def decode(
+        self,
+        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    ) -> Iterable[NDBuffer | None]:
+        raise NotImplementedError
+
     async def _encode_single(
         self, chunk_array: NDBuffer, chunk_spec: ArraySpec
     ) -> Buffer | None:
+        raise NotImplementedError
+
+    async def encode(
+        self,
+        chunks_and_specs: Iterable[tuple[NDBuffer | None, ArraySpec]],
+    ) -> Iterable[Buffer | None]:
         raise NotImplementedError
 
 

--- a/zarr_sparse/combine.py
+++ b/zarr_sparse/combine.py
@@ -1,0 +1,68 @@
+import itertools
+
+import numpy as np
+
+
+def tiles_by_id(parts):
+    return {
+        np.unravel_index(index, parts.shape): array
+        for index, array in enumerate(parts.flatten())
+    }
+
+
+def until_nth(index):
+    def indexer(val):
+        return val[:index]
+
+    return indexer
+
+
+def as_item_key(key):
+    def wrapper(it):
+        return key(it[0])
+
+    return wrapper
+
+
+def groupby_mapping(mapping, key):
+    wrapped_key = as_item_key(key)
+    raw_groups = itertools.groupby(
+        sorted(mapping.items(), key=wrapped_key), key=wrapped_key
+    )
+    return ((key, (el for _, el in group)) for key, group in raw_groups)
+
+
+def combine_nd(parts):
+    tiles = tiles_by_id(parts)
+    xp = parts.flat[0].__array_namespace__()
+
+    # innermost to outermost
+    for axis in range(parts.ndim - 1, -1, -1):
+        tiles = {
+            key: xp.concat(list(arrays), axis=axis)
+            for key, arrays in groupby_mapping(tiles, key=until_nth(axis))
+        }
+
+    return next(iter(tiles.values()))
+
+
+def expand_chunks(chunks, shape):
+    def _expand(chunkspec, size):
+        if chunkspec == -1:
+            return (size,)
+        elif isinstance(chunkspec, int):
+            n_full_chunks, remainder = divmod(size, chunkspec)
+            chunks = (chunkspec,) * n_full_chunks
+
+            if remainder > 0:
+                chunks += (remainder,)
+
+            return chunks
+
+        chunkspec = tuple(chunkspec)
+        if sum(chunkspec) != size:
+            raise ValueError(f"chunks don't add up to the full size: {chunkspec}")
+
+        return chunkspec
+
+    return tuple(_expand(chunkspec, size) for chunkspec, size in zip(chunks, shape))

--- a/zarr_sparse/combine.py
+++ b/zarr_sparse/combine.py
@@ -44,25 +44,3 @@ def combine_nd(parts):
         }
 
     return next(iter(tiles.values()))
-
-
-def expand_chunks(chunks, shape):
-    def _expand(chunkspec, size):
-        if chunkspec == -1:
-            return (size,)
-        elif isinstance(chunkspec, int):
-            n_full_chunks, remainder = divmod(size, chunkspec)
-            chunks = (chunkspec,) * n_full_chunks
-
-            if remainder > 0:
-                chunks += (remainder,)
-
-            return chunks
-
-        chunkspec = tuple(chunkspec)
-        if sum(chunkspec) != size:
-            raise ValueError(f"chunks don't add up to the full size: {chunkspec}")
-
-        return chunkspec
-
-    return tuple(_expand(chunkspec, size) for chunkspec, size in zip(chunks, shape))

--- a/zarr_sparse/comparison.py
+++ b/zarr_sparse/comparison.py
@@ -1,0 +1,78 @@
+import numpy as np
+
+from zarr_sparse.sparse import extract_arrays
+
+
+def compare_fill_value(a, b):
+    if np.isnan(a) and np.isnan(b):
+        return True
+
+    return a == b
+
+
+def sparse_equal(a, b):
+    if type(a) is not type(b):
+        return False
+
+    if a.shape != b.shape or a.dtype != b.dtype or a.nnz != b.nnz:
+        return False
+
+    metadata_a, (data_a, *coords_a) = extract_arrays(a)
+    metadata_b, (data_b, *coords_b) = extract_arrays(b)
+
+    if not compare_fill_value(metadata_a["fill_value"], metadata_b["fill_value"]):
+        return False
+
+    if not np.array_equal(a.coords, b.coords):
+        return False
+
+    return np.array_equal(a.data, b.data)
+
+
+def format_sparse_diff(a, b):
+    lines = [
+        "Sparse arrays differ:",
+    ]
+
+    equal_types = type(a) is type(b)
+    equal_shapes = a.shape == b.shape
+    equal_dtypes = a.dtype == b.dtype
+    equal_nnz = a.nnz == b.nnz
+
+    metadata_a, (data_a, *coords_a) = extract_arrays(a)
+    metadata_b, (data_b, *coords_b) = extract_arrays(b)
+
+    equal_fill_values = compare_fill_value(
+        metadata_a["fill_value"], metadata_b["fill_value"]
+    )
+
+    if not (
+        equal_types
+        and equal_shapes
+        and equal_dtypes
+        and equal_nnz
+        and equal_fill_values
+    ):
+        lines.extend(
+            [
+                "",
+                f"L  {repr(a)}",
+                f"R  {repr(a)}",
+            ]
+        )
+
+    lines.extend(["", "Comparing data:"])
+
+    if any(not np.array_equal(c_a, c_b) for c_a, c_b in zip(coords_a, coords_b)):
+        lines.append("- Coords are different")
+
+    if not np.array_equal(data_a, data_b):
+        lines.append("- Data is different")
+
+    return "\n".join(lines)
+
+
+def assert_sparse_equal(a, b):
+    __tracebackhide__ = True
+
+    assert sparse_equal(a, b), format_sparse_diff(a, b)

--- a/zarr_sparse/comparison.py
+++ b/zarr_sparse/comparison.py
@@ -4,8 +4,8 @@ from zarr_sparse.sparse import extract_arrays
 
 
 def compare_fill_value(a, b):
-    if np.isnan(a) and np.isnan(b):
-        return True
+    if np.isnan(a) or np.isnan(b):
+        return np.isnan(a) and np.isnan(b)
 
     return a == b
 

--- a/zarr_sparse/slices.py
+++ b/zarr_sparse/slices.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/zarr_sparse/slices.py
+++ b/zarr_sparse/slices.py
@@ -28,62 +28,40 @@ def slice_to_chunk_indices(slice_, bounds):
     return tuple(int(_) for _ in selected)
 
 
-def decompose_slice(slice_, offsets, chunks, local=False):
-    chunk_indices = slice_to_chunk_indices(slice_, offsets, chunks)
-    total_size = sum(chunks)
+def intersect_slice(a, b):
+    start = a.start if a.start >= b.start else b.start
+    stop = a.stop if a.stop <= b.stop else b.stop
+
+    return slice(start, stop, a.step)
+
+
+def decompose_slice(slice_, bounds):
+    def _decompose(slice_, lower, upper):
+        chunk_slice = slice(lower, upper, 1)
+
+        global_slice = intersect_slice(slice_, chunk_slice)
+
+        start = global_slice.start - lower
+        stop = global_slice.stop - lower
+        local_slice = slice(start, stop, slice_.step)
+
+        return local_slice, global_slice
+
+    total_size = bounds[-1].item()
+
+    slice_ = normalize_slice(slice_, total_size)
+    chunk_indices = slice_to_chunk_indices(slice_, bounds)
 
     decomposed = {
-        index: (
-            slice_slice(
-                slice_,
-                slice(int(offsets[index]), int(offsets[index]) + chunks[index], 1),
-                total_size,
-            )
-            if not local
-            else slice(
-                slice_.start - int(offsets[index]),
-                slice_.stop - int(offsets[index]),
-                slice_.step,
-            )
-        )
+        index: _decompose(slice_, int(bounds[index]), int(bounds[index + 1]))
         for index in chunk_indices
     }
-    return list(decomposed.items())
+    return [(index, local, global_) for index, (local, global_) in decomposed.items()]
 
 
-def decompose_slices(slices, all_offsets, all_chunks, local=False):
+def decompose_slices(slices, all_bounds):
     decomposed = (
-        decompose_slice(slice_, offsets, chunks, local=local)
-        for slice_, offsets, chunks in zip(slices, all_offsets, all_chunks)
+        decompose_slice(slice_, bounds) for slice_, bounds in zip(slices, all_bounds)
     )
     combined = [tuple(zip(*elements)) for elements in itertools.product(*decomposed)]
     return combined
-
-
-def slice_slice(old_slice: slice, applied_slice: slice, size: int) -> slice:
-    """Given a slice and the size of the dimension to which it will be applied,
-    index it with another slice to return a new slice equivalent to applying
-    the slices sequentially
-    """
-    old_slice = normalize_slice(old_slice, size)
-
-    size_after_old_slice = len(range(old_slice.start, old_slice.stop, old_slice.step))
-    if size_after_old_slice == 0:
-        # nothing left after applying first slice
-        return slice(0)
-
-    applied_slice = normalize_slice(applied_slice, size_after_old_slice)
-
-    start = old_slice.start + applied_slice.start * old_slice.step
-    if start < 0:
-        # nothing left after applying second slice
-        # (can only happen for old_slice.step < 0, e.g. [10::-1], [20:])
-        return slice(0)
-
-    stop = old_slice.start + applied_slice.stop * old_slice.step
-    if stop < 0:
-        stop = None
-
-    step = old_slice.step * applied_slice.step
-
-    return slice(start, stop, step)

--- a/zarr_sparse/slices.py
+++ b/zarr_sparse/slices.py
@@ -1,0 +1,82 @@
+import itertools
+
+import numpy as np
+
+
+def slice_size(slice_: slice[int | None], size: int) -> int:
+    return len(range(*slice_.indices(size)))
+
+
+def normalize_slice(slice_: slice[int | None], size: int) -> slice[int]:
+    return slice(*slice_.indices(size))
+
+
+def slice_to_chunk_indices(slice_, offsets, chunks):
+    condition = (slice_.start <= offsets) & (slice_.stop <= offsets + chunks)
+    selected = np.flatnonzero(condition)
+
+    if selected.size == 0:
+        raise ValueError(f"Selected chunk out of bounds: {slice_}")
+
+    return tuple(int(_) for _ in selected)
+
+
+def decompose_slice(slice_, offsets, chunks, local=False):
+    chunk_indices = slice_to_chunk_indices(slice_, offsets, chunks)
+    total_size = sum(chunks)
+
+    decomposed = {
+        index: (
+            slice_slice(
+                slice_,
+                slice(int(offsets[index]), int(offsets[index]) + chunks[index], 1),
+                total_size,
+            )
+            if not local
+            else slice(
+                slice_.start - int(offsets[index]),
+                slice_.stop - int(offsets[index]),
+                slice_.step,
+            )
+        )
+        for index in chunk_indices
+    }
+    return list(decomposed.items())
+
+
+def decompose_slices(slices, all_offsets, all_chunks, local=False):
+    decomposed = (
+        decompose_slice(slice_, offsets, chunks, local=local)
+        for slice_, offsets, chunks in zip(slices, all_offsets, all_chunks)
+    )
+    combined = [tuple(zip(*elements)) for elements in itertools.product(*decomposed)]
+    return combined
+
+
+def slice_slice(old_slice: slice, applied_slice: slice, size: int) -> slice:
+    """Given a slice and the size of the dimension to which it will be applied,
+    index it with another slice to return a new slice equivalent to applying
+    the slices sequentially
+    """
+    old_slice = normalize_slice(old_slice, size)
+
+    size_after_old_slice = len(range(old_slice.start, old_slice.stop, old_slice.step))
+    if size_after_old_slice == 0:
+        # nothing left after applying first slice
+        return slice(0)
+
+    applied_slice = normalize_slice(applied_slice, size_after_old_slice)
+
+    start = old_slice.start + applied_slice.start * old_slice.step
+    if start < 0:
+        # nothing left after applying second slice
+        # (can only happen for old_slice.step < 0, e.g. [10::-1], [20:])
+        return slice(0)
+
+    stop = old_slice.start + applied_slice.stop * old_slice.step
+    if stop < 0:
+        stop = None
+
+    step = old_slice.step * applied_slice.step
+
+    return slice(start, stop, step)

--- a/zarr_sparse/slices.py
+++ b/zarr_sparse/slices.py
@@ -13,8 +13,13 @@ def normalize_slice(slice_: slice[int | None], size: int) -> slice[int]:
     return slice(*slice_.indices(size))
 
 
-def slice_to_chunk_indices(slice_, offsets, chunks):
-    condition = (slice_.start <= offsets) & (slice_.stop <= offsets + chunks)
+def slice_to_chunk_indices(slice_, bounds):
+    fully_contained = (slice_.start <= bounds[:-1]) & (slice_.stop >= bounds[1:])
+    partially_contained = (
+        (slice_.start >= bounds[:-1]) & (slice_.start < bounds[1:])
+    ) | ((slice_.stop > bounds[:-1]) & (slice_.stop <= bounds[1:]))
+    condition = fully_contained | partially_contained
+
     selected = np.flatnonzero(condition)
 
     if selected.size == 0:

--- a/zarr_sparse/sparse.py
+++ b/zarr_sparse/sparse.py
@@ -2,6 +2,8 @@ from functools import singledispatch
 
 import numpy as np
 
+sparse_keys = ["sparse-kind", "compressed_axes"]
+
 
 @singledispatch
 def extract_arrays(x):

--- a/zarr_sparse/sparse.py
+++ b/zarr_sparse/sparse.py
@@ -1,5 +1,7 @@
 from functools import singledispatch
 
+import numpy as np
+
 
 @singledispatch
 def extract_arrays(x):
@@ -18,6 +20,51 @@ def extract_arrays(x):
         The arrays the sparse array consists of.
     """
     raise NotImplementedError(f"unknown array type: {type(x)}")
+
+
+converters = {}
+
+
+def register_converter(library_name, sparse_kind):
+    def wrapper(func):
+        library_converters = converters.setdefault(library_name, {})
+        library_converters[sparse_kind] = func
+
+        return func
+
+    return wrapper
+
+
+def assemble_array(metadata, arrays, library):
+    """create a sparse array from metadata, arrays, and a given library
+
+    Parameters
+    ----------
+    metadata : dict
+        A description of the sparse array, including the kind.
+    arrays : tuple of array-like
+        The arrays the sparse array consists of.
+    library : str
+        The sparse array library to use.
+
+    Returns
+    -------
+    x
+        The sparse array.
+    """
+    converter_library = converters.get(library)
+    if converter_library is None:
+        raise ValueError(
+            f"unknown array library: {library}."
+            f"Choose one of {', '.join(repr(x) for x in converters)}"
+        )
+
+    sparse_format = metadata.pop("sparse-kind")
+    converter = converter_library.get(sparse_format)
+    if converter is None:
+        raise ValueError(f"array library {library} does not implement {sparse_format}.")
+
+    return converter(metadata, arrays)
 
 
 try:
@@ -45,6 +92,25 @@ try:
         arrays = (x.data, x.indices, x.indptr)
         return metadata, arrays
 
+    @register_converter("pydata-sparse", "coo")
+    def _(metadata, arrays):
+        data, *coords = arrays
+        return sparse.COO(
+            coords=coords,
+            data=data,
+            fill_value=metadata["fill_value"],
+            shape=metadata["shape"],
+        )
+
+    @register_converter("pydata-sparse", "gcxs")
+    def _(metadata, arrays):
+        return sparse.GCXS(
+            tuple(arrays),
+            fill_value=metadata["fill_value"],
+            shape=metadata["shape"],
+            compressed_axes=metadata["compressed_axes"],
+        )
+
 except ImportError:
     pass
 
@@ -65,6 +131,17 @@ try:
         arrays = x.data, *x.coords
 
         return metadata, arrays
+
+    @register_converter("scipy-sparse", "coo")
+    def _(metadata, arrays):
+        if metadata["fill_value"] != 0:
+            raise ValueError(f"fill_value not supported: {metadata['fill_value']}")
+
+        data, *coords = arrays
+
+        return scipy.sparse.coo_array(
+            (data, np.stack(coords, axis=0)), shape=metadata["shape"]
+        )
 
 except ImportError:
     pass

--- a/zarr_sparse/tests/generate.py
+++ b/zarr_sparse/tests/generate.py
@@ -1,0 +1,56 @@
+import itertools
+
+import numpy as np
+import sparse
+
+from zarr_sparse.chunks import expand_chunks
+
+
+def create_pydata_coo_array(
+    nnz: int,
+    shape: tuple[int, ...],
+    dtype: np.dtype[np.bool | np.integer | np.floating],
+    fill_value: bool | int | float,
+):
+    rng = np.random.default_rng(seed=0)
+
+    if np.isdtype(dtype, "bool"):
+        data = rng.integers(low=0, high=1, size=nnz).astype(dtype)
+        fill_value = rng.choice([True, False]).item()
+    elif np.isdtype(dtype, "integral"):
+        iinfo = np.iinfo(dtype)
+        data = rng.integers(
+            low=iinfo.min, high=iinfo.max, size=nnz, dtype=dtype, endpoint=True
+        )
+        fill_value = rng.integers(
+            low=iinfo.min, high=iinfo.max, size=1, endpoint=True
+        ).item()
+    else:
+        data = rng.random(size=nnz, dtype=dtype)
+        fill_value = rng.random(size=1, dtype=dtype).item()
+
+    coords = np.stack([rng.integers(dim_size, size=nnz) for dim_size in shape], axis=0)
+
+    return sparse.COO(data=data, coords=coords, shape=shape, fill_value=fill_value)
+
+
+def create_chunk_slices(shape, chunks):
+    if not isinstance(chunks[0], tuple):
+        expanded_chunks = expand_chunks(chunks, shape)
+    else:
+        expanded_chunks = chunks
+
+    offsets = tuple(
+        np.cumulative_sum(np.asarray(c, dtype="uint64"), include_initial=True)
+        for c in expanded_chunks
+    )
+
+    chunk_bounds = tuple(
+        tuple(slice(int(lower), int(upper)) for lower, upper in zip(o[:-1], o[1:]))
+        for o in offsets
+    )
+
+    if len(shape) == 1:
+        return [(slice_,) for slice_ in chunk_bounds[0]]
+    else:
+        return list(itertools.product(*chunk_bounds))

--- a/zarr_sparse/tests/strategies.py
+++ b/zarr_sparse/tests/strategies.py
@@ -3,7 +3,7 @@ import hypothesis.strategies as st
 import numpy as np
 import sparse
 
-from zarr_sparse.utils import expand_chunks
+from zarr_sparse.chunks import expand_chunks
 
 nnz = st.integers(min_value=1, max_value=30)
 

--- a/zarr_sparse/tests/strategies.py
+++ b/zarr_sparse/tests/strategies.py
@@ -1,9 +1,8 @@
 import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
 import numpy as np
-import sparse
 
-from zarr_sparse.chunks import expand_chunks
+from zarr_sparse.tests.generate import create_chunk_slices, create_pydata_coo_array
 
 nnz = st.integers(min_value=1, max_value=30)
 
@@ -12,29 +11,11 @@ nnz = st.integers(min_value=1, max_value=30)
 def _chunks(draw, shapes):
     shape = draw(shapes)
 
-    n_chunks = tuple(draw(st.integers(min_value=1, max_value=size)) for size in shape)
+    n_chunks = tuple(
+        draw(st.integers(min_value=1, max_value=size // 2 or 1)) for size in shape
+    )
 
     return tuple(size // n for size, n in zip(shape, n_chunks))
-
-
-@st.composite
-def _slices(draw, shapes, chunks):
-    shape = draw(shapes)
-    chunks_ = draw(chunks)
-
-    expanded_chunks = expand_chunks(chunks_, shape)
-
-    offsets = tuple(
-        np.cumulative_sum(np.asarray(c, dtype="uint64"), include_initial=True)
-        for c in expanded_chunks
-    )
-
-    chunk_bounds = tuple(
-        tuple(slice(lower, upper) for lower, upper in zip(o[:-1], o[1:]))
-        for o in offsets
-    )
-
-    return tuple(draw(st.sampled_from(c)) for c in chunk_bounds)
 
 
 _dtypes = (
@@ -42,49 +23,25 @@ _dtypes = (
     | npst.integer_dtypes(endianness="=")
     | npst.floating_dtypes(sizes=(32, 64), endianness="=")
 )
-_shapes = npst.array_shapes(min_dims=1, max_dims=4, min_side=3, max_side=1000)
+_shapes = npst.array_shapes(min_dims=1, max_dims=4, min_side=1, max_side=100)
 
 dtypes = st.shared(_dtypes, key="dtypes")
 fill_values = npst.arrays(st.shared(_dtypes, key="dtypes"), shape=(1,)).map(
     lambda x: x.item()
 )
 shapes = st.shared(_shapes, key="shapes")
-chunks = st.shared(_chunks(st.shared(_shapes, key="shapes")), key="chunks")
-slices = _slices(shapes, chunks)
+__chunks = _chunks(st.shared(_shapes, key="shapes"))
+chunks = st.shared(__chunks, key="chunks")
+chunk_slices = st.builds(
+    create_chunk_slices,
+    st.shared(_shapes, key="shapes"),
+    st.shared(__chunks, key="chunks"),
+)
 
 
 def sparse_coo_arrays(
     *, nnz=nnz, shapes=shapes, dtypes=dtypes, fill_values=fill_values
 ):
-    def _create_coo_array(
-        nnz: int,
-        shape: tuple[int, ...],
-        dtype: np.dtype[np.bool | np.integer | np.floating],
-        fill_value: bool | int | float,
-    ):
-        rng = np.random.default_rng(seed=0)
-
-        if np.isdtype(dtype, "bool"):
-            data = rng.integers(low=0, high=1, size=nnz).astype(dtype)
-            fill_value = rng.choice([True, False]).item()
-        elif np.isdtype(dtype, "integral"):
-            iinfo = np.iinfo(dtype)
-            data = rng.integers(
-                low=iinfo.min, high=iinfo.max, size=nnz, dtype=dtype, endpoint=True
-            )
-            fill_value = rng.integers(
-                low=iinfo.min, high=iinfo.max, size=1, endpoint=True
-            ).item()
-        else:
-            data = rng.random(size=nnz, dtype=dtype)
-            fill_value = rng.random(size=1, dtype=dtype).item()
-
-        coords = np.stack(
-            [rng.integers(dim_size, size=nnz) for dim_size in shape], axis=0
-        )
-
-        return sparse.COO(data=data, coords=coords, shape=shape, fill_value=fill_value)
-
     if isinstance(nnz, int):
         nnz = st.just(nnz)
     if isinstance(shapes, tuple):
@@ -94,4 +51,4 @@ def sparse_coo_arrays(
     if isinstance(fill_values, (bool, int, float)):
         fill_values = st.just(fill_values)
 
-    return st.builds(_create_coo_array, nnz, shapes, dtypes, fill_values)
+    return st.builds(create_pydata_coo_array, nnz, shapes, dtypes, fill_values)

--- a/zarr_sparse/tests/strategies.py
+++ b/zarr_sparse/tests/strategies.py
@@ -1,0 +1,97 @@
+import hypothesis.extra.numpy as npst
+import hypothesis.strategies as st
+import numpy as np
+import sparse
+
+from zarr_sparse.utils import expand_chunks
+
+nnz = st.integers(min_value=1, max_value=30)
+
+
+@st.composite
+def _chunks(draw, shapes):
+    shape = draw(shapes)
+
+    n_chunks = tuple(draw(st.integers(min_value=1, max_value=size)) for size in shape)
+
+    return tuple(size // n for size, n in zip(shape, n_chunks))
+
+
+@st.composite
+def _slices(draw, shapes, chunks):
+    shape = draw(shapes)
+    chunks_ = draw(chunks)
+
+    expanded_chunks = expand_chunks(chunks_, shape)
+
+    offsets = tuple(
+        np.cumulative_sum(np.asarray(c, dtype="uint64"), include_initial=True)
+        for c in expanded_chunks
+    )
+
+    chunk_bounds = tuple(
+        tuple(slice(lower, upper) for lower, upper in zip(o[:-1], o[1:]))
+        for o in offsets
+    )
+
+    return tuple(draw(st.sampled_from(c)) for c in chunk_bounds)
+
+
+_dtypes = (
+    npst.boolean_dtypes()
+    | npst.integer_dtypes(endianness="=")
+    | npst.floating_dtypes(sizes=(32, 64), endianness="=")
+)
+_shapes = npst.array_shapes(min_dims=1, max_dims=4, min_side=3, max_side=1000)
+
+dtypes = st.shared(_dtypes, key="dtypes")
+fill_values = npst.arrays(st.shared(_dtypes, key="dtypes"), shape=(1,)).map(
+    lambda x: x.item()
+)
+shapes = st.shared(_shapes, key="shapes")
+chunks = st.shared(_chunks(st.shared(_shapes, key="shapes")), key="chunks")
+slices = _slices(shapes, chunks)
+
+
+def sparse_coo_arrays(
+    *, nnz=nnz, shapes=shapes, dtypes=dtypes, fill_values=fill_values
+):
+    def _create_coo_array(
+        nnz: int,
+        shape: tuple[int, ...],
+        dtype: np.dtype[np.bool | np.integer | np.floating],
+        fill_value: bool | int | float,
+    ):
+        rng = np.random.default_rng(seed=0)
+
+        if np.isdtype(dtype, "bool"):
+            data = rng.integers(low=0, high=1, size=nnz).astype(dtype)
+            fill_value = rng.choice([True, False]).item()
+        elif np.isdtype(dtype, "integral"):
+            iinfo = np.iinfo(dtype)
+            data = rng.integers(
+                low=iinfo.min, high=iinfo.max, size=nnz, dtype=dtype, endpoint=True
+            )
+            fill_value = rng.integers(
+                low=iinfo.min, high=iinfo.max, size=1, endpoint=True
+            ).item()
+        else:
+            data = rng.random(size=nnz, dtype=dtype)
+            fill_value = rng.random(size=1, dtype=dtype).item()
+
+        coords = np.stack(
+            [rng.integers(dim_size, size=nnz) for dim_size in shape], axis=0
+        )
+
+        return sparse.COO(data=data, coords=coords, shape=shape, fill_value=fill_value)
+
+    if isinstance(nnz, int):
+        nnz = st.just(nnz)
+    if isinstance(shapes, tuple):
+        shapes = st.just(shapes)
+    if isinstance(dtypes, np.dtype):
+        dtypes = st.just(dtypes)
+    if isinstance(fill_values, (bool, int, float)):
+        fill_values = st.just(fill_values)
+
+    return st.builds(_create_coo_array, nnz, shapes, dtypes, fill_values)

--- a/zarr_sparse/tests/test_combine.py
+++ b/zarr_sparse/tests/test_combine.py
@@ -1,0 +1,163 @@
+import numpy as np
+import pytest
+
+from zarr_sparse import combine
+
+
+@pytest.mark.parametrize(
+    ["parts", "expected_ids"],
+    (
+        (
+            np.array(
+                [[{"x": 1}, {"x": 2}, {"x": 3}], [{"x": 4}, {"x": 5}, {"x": 6}]],
+                dtype=object,
+            ),
+            [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)],
+        ),
+        (
+            np.array(
+                [[[{"x": 1}], [{"x": 2}]], [[{"x": 3}], [{"x": 4}]]], dtype=object
+            ),
+            [(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0)],
+        ),
+    ),
+)
+def test_tiles_by_id(parts, expected_ids):
+    expected = {id_: {"x": index} for index, id_ in enumerate(expected_ids, start=1)}
+
+    actual = combine.tiles_by_id(parts)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("index", [1, 4, 8, -1])
+def test_until_nth(index):
+    selector = combine.until_nth(index)
+
+    sequence = range(20)
+
+    actual = selector(sequence)
+
+    assert actual == sequence[:index]
+
+
+@pytest.mark.parametrize("key", [lambda x: x**2, lambda x: x * 2])
+def test_as_item_key(key):
+    mapping = dict.fromkeys(range(20))
+
+    wrapped = combine.as_item_key(key)
+
+    expected = [key(x) for x in mapping.keys()]
+    actual = list(map(wrapped, mapping.items()))
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["axis", "expected_keys"],
+    (
+        (
+            2,
+            [
+                [(0, 0, 0), (0, 0, 1), (0, 0, 2), (0, 0, 3)],
+                [(0, 1, 0), (0, 1, 1), (0, 1, 2), (0, 1, 3)],
+                [(1, 0, 0), (1, 0, 1), (1, 0, 2), (1, 0, 3)],
+                [(1, 1, 0), (1, 1, 1), (1, 1, 2), (1, 1, 3)],
+            ],
+        ),
+        (1, [[(0, 0), (0, 1)], [(1, 0), (1, 1)]]),
+        (0, [[(0,), (1,)]]),
+    ),
+)
+def test_groupby_mapping(axis, expected_keys):
+    keys = [
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 0, 2),
+        (0, 0, 3),
+        (0, 1, 0),
+        (0, 1, 1),
+        (0, 1, 2),
+        (0, 1, 3),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 0, 2),
+        (1, 0, 3),
+        (1, 1, 0),
+        (1, 1, 1),
+        (1, 1, 2),
+        (1, 1, 3),
+    ]
+    filtered = list(dict.fromkeys(k[: axis + 1] for k in keys))
+    mapping = {k: v for v, k in enumerate(filtered)}
+
+    expected = {
+        group[0][:axis] if axis > 0 else (): [mapping[k] for k in group]
+        for group in expected_keys
+    }
+
+    actual = {
+        k: list(g)
+        for k, g in combine.groupby_mapping(mapping, key=combine.until_nth(axis))
+    }
+
+    assert actual == expected
+
+
+def create_grid(shapes, dtype):
+    shapes = np.asarray(shapes, dtype="uint64")
+    *grid_shape, ndim = shapes.shape
+
+    grid = np.full(shape=grid_shape, fill_value=None, dtype=object)
+    for index in range(np.prod(shapes.shape[:-1])):
+        indices = np.unravel_index(index, grid_shape)
+        shape = shapes[*indices, :]
+
+        grid[indices] = np.zeros(shape=shape, dtype=dtype)
+
+    return grid
+
+
+@pytest.mark.parametrize(
+    ["shapes", "expected"],
+    (
+        (
+            [
+                [(2, 3), (2, 3), (2, 2)],
+                [(2, 3), (2, 3), (2, 2)],
+                [(1, 3), (1, 3), (1, 2)],
+            ],
+            np.zeros(shape=(5, 8), dtype="float32"),
+        ),
+        (
+            [
+                [
+                    [(5, 3, 4), (5, 3, 4)],
+                    [(5, 3, 4), (5, 3, 4)],
+                    [(5, 1, 4), (5, 1, 4)],
+                ],
+                [
+                    [(5, 3, 4), (5, 3, 4)],
+                    [(5, 3, 4), (5, 3, 4)],
+                    [(5, 1, 4), (5, 1, 4)],
+                ],
+                [
+                    [(5, 3, 4), (5, 3, 4)],
+                    [(5, 3, 4), (5, 3, 4)],
+                    [(5, 1, 4), (5, 1, 4)],
+                ],
+                [
+                    [(2, 3, 4), (2, 3, 4)],
+                    [(2, 3, 4), (2, 3, 4)],
+                    [(2, 1, 4), (2, 1, 4)],
+                ],
+            ],
+            np.zeros(shape=(17, 7, 8), dtype="int16"),
+        ),
+    ),
+)
+def test_combine_nd(shapes, expected):
+    parts = create_grid(shapes, expected.dtype)
+
+    actual = combine.combine_nd(parts)
+
+    np.testing.assert_equal(actual, expected)

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -1,6 +1,11 @@
+import numpy as np
 import pytest
 
-from zarr_sparse.buffer import ChunkGrid, SparseNDBuffer, normalize_slice, slice_size
+from zarr_sparse.buffer import (
+    ChunkGrid,
+    normalize_slice,
+    slice_size,
+)
 
 
 @pytest.mark.parametrize(
@@ -29,3 +34,59 @@ def test_normalize_slice(slice_, size, expected):
     actual = normalize_slice(slice_, size)
 
     assert actual == expected
+
+
+class TestChunkGrid:
+    @pytest.mark.parametrize(
+        "params",
+        (
+            {"shape": (2, 3), "dtype": "int64", "order": "C", "fill_value": 0},
+            {"shape": (3,), "dtype": "int8", "order": "F", "fill_value": 15},
+            {"shape": (10, 1, 15), "dtype": "float32", "order": "C", "fill_value": 0.0},
+        ),
+    )
+    def test_init(self, params):
+        obj = ChunkGrid(**params)
+
+        assert {k: getattr(obj, f"_{k}") for k in params} == params
+        np.testing.assert_equal(
+            obj._data,
+            np.full((1,) * len(obj._shape), dtype=object, fill_value=None),
+        )
+        assert obj._chunks == params["shape"]
+
+    @pytest.mark.parametrize("shape", ((3, 4), (1, 5, 10)))
+    def test_shape(self, shape):
+        obj = ChunkGrid(shape=shape, dtype="float32", order="C", fill_value=0.0)
+
+        assert obj.shape == shape
+
+    @pytest.mark.parametrize("dtype", ("float32", "int64"))
+    def test_dtype(self, dtype):
+        obj = ChunkGrid(shape=(4, 3), dtype=dtype, order="C", fill_value=0.0)
+
+        assert obj.dtype == dtype
+
+    @pytest.mark.parametrize("order", ("C", "F"))
+    def test_order(self, order):
+        obj = ChunkGrid(shape=(4, 3), dtype="int32", order=order, fill_value=0.0)
+
+        assert obj.order == order
+
+    @pytest.mark.parametrize("fill_value", (0, 1))
+    def test_fill_value(self, fill_value):
+        obj = ChunkGrid(shape=(4, 3), dtype="int32", order="C", fill_value=fill_value)
+
+        assert obj.fill_value == fill_value
+
+    @pytest.mark.parametrize("chunks", ((2, 1), (4, 2)))
+    def test_chunks(self, chunks):
+        obj = ChunkGrid(
+            shape=(4, 3),
+            dtype="int32",
+            order="C",
+            fill_value=0,
+            chunks=chunks,
+        )
+
+        assert obj.chunks == chunks

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -1,12 +1,7 @@
 import numpy as np
 import pytest
 
-from zarr_sparse.buffer import (
-    ChunkGrid,
-    decompose_by_chunks,
-    normalize_slice,
-    slice_size,
-)
+from zarr_sparse.buffer import ChunkGrid, normalize_slice, slice_size
 
 
 @pytest.mark.parametrize(
@@ -35,46 +30,6 @@ def test_normalize_slice(slice_, size, expected):
     actual = normalize_slice(slice_, size)
 
     assert actual == expected
-
-
-@pytest.mark.parametrize(
-    ["indexer", "chunks", "expected"],
-    (
-        (
-            slice(None),
-            (5, 5, 5, 3),
-            {
-                0: slice(0, 5, 1),
-                1: slice(0, 5, 1),
-                2: slice(0, 5, 1),
-                3: slice(0, 3, 1),
-            },
-        ),
-        (slice(1, 5, 2), (10, 10, 1), {0: slice(1, 5, 2)}),
-        (4, (3, 3), {1: 1}),
-        (
-            np.array([1, 2, 4, 6]),
-            (3, 3, 2),
-            {0: np.array([1, 2]), 1: np.array([1]), 2: np.array([0])},
-        ),
-    ),
-)
-def test_decompose_by_chunks(indexer, chunks, expected):
-    def compare(indexer1, indexer2):
-        if type(indexer1) is not type(indexer2):
-            return False
-
-        if isinstance(indexer1, (int, slice)):
-            return indexer1 == indexer2
-
-        return np.array_equal(indexer1, indexer2)
-
-    actual = decompose_by_chunks(indexer, chunks)
-
-    assert actual.keys() == expected.keys(), "selected chunks are different"
-    assert all(
-        compare(actual[k], expected[k]) for k in actual.keys()
-    ), "chunk indexers are different"
 
 
 class TestChunkGrid:

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -1,0 +1,31 @@
+import pytest
+
+from zarr_sparse.buffer import ChunkGrid, SparseNDBuffer, normalize_slice, slice_size
+
+
+@pytest.mark.parametrize(
+    ["slice_", "size", "expected"],
+    (
+        (slice(None), 10, 10),
+        (slice(None, 4), 10, 4),
+        (slice(1, None), 3, 2),
+    ),
+)
+def test_slice_size(slice_, size, expected):
+    actual = slice_size(slice_, size)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["slice_", "size", "expected"],
+    (
+        (slice(None), 10, slice(0, 10, 1)),
+        (slice(None, 4), 10, slice(0, 4, 1)),
+        (slice(1, None), 3, slice(1, 3, 1)),
+    ),
+)
+def test_normalize_slice(slice_, size, expected):
+    actual = normalize_slice(slice_, size)
+
+    assert actual == expected

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -3,6 +3,7 @@ import pytest
 
 from zarr_sparse.buffer import (
     ChunkGrid,
+    decompose_by_chunks,
     normalize_slice,
     slice_size,
 )
@@ -34,6 +35,46 @@ def test_normalize_slice(slice_, size, expected):
     actual = normalize_slice(slice_, size)
 
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["indexer", "chunks", "expected"],
+    (
+        (
+            slice(None),
+            (5, 5, 5, 3),
+            {
+                0: slice(0, 5, 1),
+                1: slice(0, 5, 1),
+                2: slice(0, 5, 1),
+                3: slice(0, 3, 1),
+            },
+        ),
+        (slice(1, 5, 2), (10, 10, 1), {0: slice(1, 5, 2)}),
+        (4, (3, 3), {1: 1}),
+        (
+            np.array([1, 2, 4, 6]),
+            (3, 3, 2),
+            {0: np.array([1, 2]), 1: np.array([1]), 2: np.array([0])},
+        ),
+    ),
+)
+def test_decompose_by_chunks(indexer, chunks, expected):
+    def compare(indexer1, indexer2):
+        if type(indexer1) is not type(indexer2):
+            return False
+
+        if isinstance(indexer1, (int, slice)):
+            return indexer1 == indexer2
+
+        return np.array_equal(indexer1, indexer2)
+
+    actual = decompose_by_chunks(indexer, chunks)
+
+    assert actual.keys() == expected.keys(), "selected chunks are different"
+    assert all(
+        compare(actual[k], expected[k]) for k in actual.keys()
+    ), "chunk indexers are different"
 
 
 class TestChunkGrid:

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -1,18 +1,9 @@
-import hypothesis.strategies as st
 import numpy as np
 import pytest
-from hypothesis import given, note
 
 from zarr_sparse.buffer import ChunkGrid
 from zarr_sparse.comparison import assert_sparse_equal
 from zarr_sparse.tests.generate import create_chunk_slices, create_pydata_coo_array
-from zarr_sparse.tests.strategies import (
-    chunks,
-    dtypes,
-    nnz,
-    shapes,
-    sparse_coo_arrays,
-)
 
 
 class TestChunkGrid:
@@ -77,13 +68,31 @@ class TestChunkGrid:
 
         assert obj.chunks == expanded
 
-    @given(
-        sparse_coo_arrays(nnz=nnz, shapes=shapes, dtypes=dtypes),
-        chunks,
-        st.sampled_from(["C", "F"]),
+    @pytest.mark.parametrize(
+        ["dtype", "fill_value"],
+        (
+            ("int64", 0),
+            ("int32", 3),
+            ("float32", 0),
+            ("float64", np.nan),
+        ),
     )
-    def test_setitem_full(self, sparse_array, chunks, order):
-        note(f"input: {sparse_array=}, {chunks=}")
+    @pytest.mark.parametrize(
+        ["shape", "chunks"],
+        (
+            ((60, 3), (10, 3)),
+            ((100, 100, 100), (20, 50, 50)),
+            ((500,), (5,)),
+        ),
+    )
+    @pytest.mark.parametrize("nnz", (1, 38, 70, 150))
+    def test_setitem_full(self, nnz, shape, chunks, dtype, fill_value):
+        order = "C"
+        sparse_array = create_pydata_coo_array(
+            nnz=nnz, shape=shape, dtype=np.dtype(dtype), fill_value=fill_value
+        )
+
+        print(f"input: {sparse_array=}, {chunks=}")
 
         actual = ChunkGrid(
             shape=sparse_array.shape,
@@ -92,9 +101,9 @@ class TestChunkGrid:
             fill_value=sparse_array.fill_value,
             chunks=chunks,
         )
-        note(f"ChunkGrid (before assignment):\n{actual}")
+        print(f"ChunkGrid (before assignment):\n{actual}")
         actual[(slice(None),) * sparse_array.ndim] = sparse_array
-        note(f"ChunkGrid (after assignment):\n{actual}")
+        print(f"ChunkGrid (after assignment):\n{actual}")
 
         assert_sparse_equal(
             actual.get_value(),

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -1,35 +1,7 @@
 import numpy as np
 import pytest
 
-from zarr_sparse.buffer import ChunkGrid, normalize_slice, slice_size
-
-
-@pytest.mark.parametrize(
-    ["slice_", "size", "expected"],
-    (
-        (slice(None), 10, 10),
-        (slice(None, 4), 10, 4),
-        (slice(1, None), 3, 2),
-    ),
-)
-def test_slice_size(slice_, size, expected):
-    actual = slice_size(slice_, size)
-
-    assert actual == expected
-
-
-@pytest.mark.parametrize(
-    ["slice_", "size", "expected"],
-    (
-        (slice(None), 10, slice(0, 10, 1)),
-        (slice(None, 4), 10, slice(0, 4, 1)),
-        (slice(1, None), 3, slice(1, 3, 1)),
-    ),
-)
-def test_normalize_slice(slice_, size, expected):
-    actual = normalize_slice(slice_, size)
-
-    assert actual == expected
+from zarr_sparse.buffer import ChunkGrid
 
 
 class TestChunkGrid:

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -21,7 +21,8 @@ class TestChunkGrid:
             obj._data,
             np.full((1,) * len(obj._shape), dtype=object, fill_value=None),
         )
-        assert obj._chunks == params["shape"]
+        expected_chunks = tuple((size,) for size in params["shape"])
+        assert obj._chunks == expected_chunks
 
     @pytest.mark.parametrize("shape", ((3, 4), (1, 5, 10)))
     def test_shape(self, shape):
@@ -47,8 +48,14 @@ class TestChunkGrid:
 
         assert obj.fill_value == fill_value
 
-    @pytest.mark.parametrize("chunks", ((2, 1), (4, 2)))
-    def test_chunks(self, chunks):
+    @pytest.mark.parametrize(
+        ["chunks", "expanded"],
+        (
+            ((2, 1), ((2, 2), (1, 1, 1))),
+            ((4, 2), ((4,), (2, 1))),
+        ),
+    )
+    def test_chunks(self, chunks, expanded):
         obj = ChunkGrid(
             shape=(4, 3),
             dtype="int32",
@@ -57,4 +64,4 @@ class TestChunkGrid:
             chunks=chunks,
         )
 
-        assert obj.chunks == chunks
+        assert obj.chunks == expanded

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -113,12 +113,12 @@ class TestChunkGrid:
     @pytest.mark.parametrize(
         ["shape", "chunks"],
         (
-            ((6, 5), (2, 3)),
+            ((60, 3), (10, 3)),
             ((100, 100, 100), (20, 50, 50)),
             ((500,), (5,)),
         ),
     )
-    @pytest.mark.parametrize("nnz", (5, 15, 30))
+    @pytest.mark.parametrize("nnz", (1, 38, 70, 150))
     def test_setitem_chunks(self, nnz, shape, chunks, dtype, fill_value):
         order = "C"
         sparse_array = create_pydata_coo_array(

--- a/zarr_sparse/tests/test_slices.py
+++ b/zarr_sparse/tests/test_slices.py
@@ -1,6 +1,11 @@
+import numpy as np
 import pytest
 
-from zarr_sparse.slices import normalize_slice, slice_size
+from zarr_sparse.slices import (
+    normalize_slice,
+    slice_size,
+    slice_to_chunk_indices,
+)
 
 
 @pytest.mark.parametrize(
@@ -27,5 +32,30 @@ def test_slice_size(slice_, size, expected):
 )
 def test_normalize_slice(slice_, size, expected):
     actual = normalize_slice(slice_, size)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["size", "n_chunks", "slice_", "expected"],
+    (
+        (4, 2, slice(0, 3), (0, 1)),
+        (4, 2, slice(1, 2), (0,)),
+        (4, 2, slice(0, 2), (0,)),
+        (7, 3, slice(1, 7), (0, 1, 2, 3)),
+        (11, 5, slice(5, 11), (2, 3, 4, 5)),
+    ),
+)
+def test_slice_to_chunk_indices(size, n_chunks, slice_, expected):
+    chunksize, remainder = divmod(size, n_chunks)
+    chunks = tuple(c for c in (chunksize,) * n_chunks + (remainder,) if c > 0)
+
+    bounds = np.cumulative_sum(np.asarray(chunks, dtype="uint64"), include_initial=True)
+
+    print(f"input: {size=}, {n_chunks=}")
+    print("chunks:", chunks)
+    print("bounds:", bounds)
+
+    actual = slice_to_chunk_indices(slice_, bounds)
 
     assert actual == expected

--- a/zarr_sparse/tests/test_slices.py
+++ b/zarr_sparse/tests/test_slices.py
@@ -1,0 +1,31 @@
+import pytest
+
+from zarr_sparse.slices import normalize_slice, slice_size
+
+
+@pytest.mark.parametrize(
+    ["slice_", "size", "expected"],
+    (
+        (slice(None), 10, 10),
+        (slice(None, 4), 10, 4),
+        (slice(1, None), 3, 2),
+    ),
+)
+def test_slice_size(slice_, size, expected):
+    actual = slice_size(slice_, size)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["slice_", "size", "expected"],
+    (
+        (slice(None), 10, slice(0, 10, 1)),
+        (slice(None, 4), 10, slice(0, 4, 1)),
+        (slice(1, None), 3, slice(1, 3, 1)),
+    ),
+)
+def test_normalize_slice(slice_, size, expected):
+    actual = normalize_slice(slice_, size)
+
+    assert actual == expected

--- a/zarr_sparse/tests/test_slices.py
+++ b/zarr_sparse/tests/test_slices.py
@@ -1,7 +1,11 @@
+import itertools
+
 import numpy as np
 import pytest
 
 from zarr_sparse.slices import (
+    decompose_slice,
+    decompose_slices,
     normalize_slice,
     slice_size,
     slice_to_chunk_indices,
@@ -57,5 +61,84 @@ def test_slice_to_chunk_indices(size, n_chunks, slice_, expected):
     print("bounds:", bounds)
 
     actual = slice_to_chunk_indices(slice_, bounds)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["size", "n_chunks", "slice_", "expected"],
+    (
+        (
+            10,
+            2,
+            slice(None),
+            [(0, slice(0, 5, 1), slice(0, 5, 1)), (1, slice(0, 5, 1), slice(5, 10, 1))],
+        ),
+        (10, 2, slice(0, 5), [(0, slice(0, 5, 1), slice(0, 5, 1))]),
+        (
+            10,
+            2,
+            slice(1, 7),
+            [(0, slice(1, 5, 1), slice(1, 5, 1)), (1, slice(0, 2, 1), slice(5, 7, 1))],
+        ),
+        (
+            10,
+            5,
+            slice(5, 10),
+            [
+                (2, slice(1, 2, 1), slice(5, 6, 1)),
+                (3, slice(0, 2, 1), slice(6, 8, 1)),
+                (4, slice(0, 2, 1), slice(8, 10, 1)),
+            ],
+        ),
+        (
+            50,
+            10,
+            slice(36, 48),
+            [
+                (7, slice(1, 5, 1), slice(36, 40, 1)),
+                (8, slice(0, 5, 1), slice(40, 45, 1)),
+                (9, slice(0, 3, 1), slice(45, 48, 1)),
+            ],
+        ),
+    ),
+)
+def test_decompose_slice(size, n_chunks, slice_, expected):
+    chunksize, remainder = divmod(size, n_chunks)
+    chunks = tuple(c for c in (chunksize,) * n_chunks + (remainder,) if c > 0)
+
+    bounds = np.cumulative_sum(np.asarray(chunks, dtype="uint64"), include_initial=True)
+
+    print(f"input: {size=}, {n_chunks=}")
+    print("chunks:", chunks)
+    print("bounds:", bounds)
+
+    actual = decompose_slice(slice_, bounds)
+
+    assert actual == expected
+
+
+def test_decompose_slices():
+    # shape = (10, 9)  # for reference
+    chunks = ((3, 3, 3, 1), (2, 2, 2, 2, 1))
+
+    bounds = tuple(
+        np.cumulative_sum(np.asarray(c, dtype="uint64"), include_initial=True)
+        for c in chunks
+    )
+
+    slices = (slice(1, 6), slice(3, 8))
+
+    actual = decompose_slices(slices, bounds)
+
+    decomposed = [
+        ((0, slice(1, 3, 1), slice(1, 3, 1)), (1, slice(0, 3, 1), slice(3, 6, 1))),
+        (
+            (1, slice(1, 2, 1), slice(3, 4, 1)),
+            (2, slice(0, 2, 1), slice(4, 6, 1)),
+            (3, slice(0, 2, 1), slice(6, 8, 1)),
+        ),
+    ]
+    expected = [tuple(zip(*el)) for el in itertools.product(*decomposed)]
 
     assert actual == expected


### PR DESCRIPTION
The idea is to create a array-to-bytes codec that packs the composing arrays of sparse arrays (data, coords) into a binary blob (while compressing the arrays individually), similar to how sharding works.

This requires additional metadata to be derived from the sparse array (sparse format, fill value, compressed axes for GCXS), see #1.

When trying to actually write data to disk using the current dummy implementation, this fails:

``` python
from zarr_sparse.codec import SparseArrayCodec
import zarr
import sparse

x = sparse.full((10, 10), fill_value=0, dtype="float32")
store = zarr.storage.MemoryStore()
z = zarr.create_array(
    store=store,
    shape=x.shape,
    chunks=(1, 1),
    dtype=x.dtype,
    serializer=SparseArrayCodec(),
    filters=None,
    compressors=None,
)
z[:] = x
```

As far as I can tell, the issue is that the codec pipeline uses `NDBuffer` objects, which assume that it is possible to convert the array to host memory / numpy arrays, which for sparse arrays we actually want to avoid. Does that mean we'd have to somehow replace `NDBuffer` with something else to get this to work?

cc @joshmoore @sanketverma1704