### PR TITLE
configure the prototype on the codec class

### DIFF
--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import numpy.typing as npt
 import sparse
-from zarr.core.buffer.core import Buffer, BufferPrototype, NDBuffer
+from zarr.core.buffer.core import BufferPrototype, NDBuffer
+from zarr.core.buffer.cpu import Buffer
 from zarr.registry import register_ndbuffer
 
 from zarr_sparse.chunks import expand_chunks
@@ -288,4 +289,4 @@ buffer_prototype = BufferPrototype(buffer=Buffer, nd_buffer=SparseNDBuffer)
 
 
 def sparse_buffer_prototype() -> BufferPrototype:
-    return BufferPrototype(buffer=Buffer, nd_buffer=NDBuffer)
+    return BufferPrototype(buffer=Buffer, nd_buffer=SparseNDBuffer)

--- a/zarr_sparse/codec.py
+++ b/zarr_sparse/codec.py
@@ -16,6 +16,7 @@ from zarr.core.dtype.npy.int import BaseInt, Int64, UInt64
 from zarr.core.dtype.npy.string import FixedLengthUTF32, VariableLengthUTF8
 from zarr.registry import get_pipeline_class, register_codec
 
+from zarr_sparse.buffer import sparse_buffer_prototype
 from zarr_sparse.comparison import compare_fill_value
 from zarr_sparse.sparse import assemble_array, extract_arrays, sparse_keys
 
@@ -282,6 +283,7 @@ class SparseArrayCodec(ArrayBytesCodec):
     def __init__(self):
         self.array_codecs = (BytesCodec(), ZstdCodec())
         self.table_codecs = (BytesCodec(),)
+        self.prototype = sparse_buffer_prototype()
 
     @classmethod
     def from_dict(cls, data: dict[str, JSON]) -> Self:


### PR DESCRIPTION
This is an attempt to control the prototype (and thus the `nd_buffer` class) from the codec class. This needs [535bf78](https://github.com/zarr-developers/zarr-python/commit/535bf78b9fafdf1f9034d7018c4c1fb731299206) in `zarr`.