### PR TITLE
remove the need for passing the chunks to the buffer

### DIFF
--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -46,7 +46,7 @@ def sparse_equal(a, b, equal_nan: bool) -> bool:
 
 @register_ndbuffer
 class SparseNDBuffer(NDBuffer):
-    def __init__(self, chunk_grid) -> None:
+    def __init__(self, chunk_grid: ChunkGrid) -> None:
         if chunk_grid is None:
             raise ValueError("chunk grid is `None`")
         self._data = chunk_grid

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -120,7 +120,43 @@ class SparseNDBuffer(NDBuffer):
             # Handle None fill_value for Zarr V2
             return False
 
-        return self._data.all_equal(other, equal_nan=equal_nan)
+        # - other is multi-dim: return false if:
+        #   - shape
+        #   - dtype
+        #   - order
+        #   - fill_value
+        #   - chunk_shape
+        #   - bounds
+        #   don't match
+        # - if other is 0d:
+        #   - get a scalar
+        #   - compare every value in the chunk grid to the scalar
+        # - if other is multi-dim and matches, compare every chunk
+
+        if other.ndim != 0 and (
+            self.shape != other.shape
+            or self.dtype != other.dtype
+            or self.order != other.order
+            or self.fill_value != other.fill_value
+            or self.chunk_shape != other.chunk_shape
+            or self.bounds != other.bounds
+        ):
+            return False
+        if other.ndim == 0:
+            if isinstance(other, ChunkGrid):
+                # extract a single value from the chunk grid
+                raise NotImplementedError(
+                    "scalar wrapped by a chunk grid not supported"
+                )
+            else:
+                scalar = other
+            to_compare = ((c, scalar) for c in self._data.data.values())
+        else:
+            to_compare = zip(
+                self._data.data.values(), other._data.data.values().ravel().tolist()
+            )
+
+        return all(sparse_equal(a, b, equal_nan=equal_nan) for a, b in to_compare)
 
 
 buffer_prototype = BufferPrototype(buffer=Buffer, nd_buffer=SparseNDBuffer)

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -12,6 +12,7 @@ from zarr.registry import register_ndbuffer
 from zarr_sparse.chunk_grid import ChunkGrid
 from zarr_sparse.combine import combine_nd
 from zarr_sparse.slices import slice_size
+from zarr_sparse.utils import as_decorator
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -44,7 +45,7 @@ def sparse_equal(a, b, equal_nan: bool) -> bool:
     return sparse.equal(a, other, equal_nan=equal_nan)
 
 
-@register_ndbuffer
+@as_decorator(register_ndbuffer)
 class SparseNDBuffer(NDBuffer):
     def __init__(self, chunk_grid: ChunkGrid) -> None:
         if chunk_grid is None:

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -96,7 +96,7 @@ class SparseNDBuffer(NDBuffer):
         raise NotImplementedError("can't convert to `numpy`")
 
     def as_ndarray_like(self):
-        return combine_nd(self._data)
+        return combine_nd(self._data.data)
 
     def __getitem__(self, key: Any) -> Self:
         return self.__class__(self._data[key])

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -101,7 +101,7 @@ class SparseNDBuffer(NDBuffer):
         return combine_nd(self._data)
 
     def __getitem__(self, key: Any) -> Self:
-        return self.__class__(self._data.__getitem__(key))
+        return self.__class__(self._data[key])
 
     def __setitem__(self, key: Any, value: Any) -> None:
         if isinstance(value, NDBuffer):
@@ -114,7 +114,7 @@ class SparseNDBuffer(NDBuffer):
             # fill value
             value = sparse.full(slice_sizes, fill_value=value, dtype=value.dtype)
 
-        self._data.__setitem__(key, value)
+        self._data[key] = value
 
     def all_equal(self, other: Any, equal_nan: bool = True) -> bool:
         """Compare to `other` using np.array_equal."""

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -46,8 +46,6 @@ def sparse_equal(a, b, equal_nan: bool) -> bool:
 
 @register_ndbuffer
 class SparseNDBuffer(NDBuffer):
-    chunked = True
-
     def __init__(self, chunk_grid) -> None:
         if chunk_grid is None:
             raise ValueError("chunk grid is `None`")

--- a/zarr_sparse/buffer.py
+++ b/zarr_sparse/buffer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import math
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -10,13 +9,13 @@ from zarr.core.buffer.core import BufferPrototype, NDBuffer
 from zarr.core.buffer.cpu import Buffer
 from zarr.registry import register_ndbuffer
 
-from zarr_sparse.chunks import expand_chunks
+from zarr_sparse.chunk_grid import ChunkGrid
 from zarr_sparse.combine import combine_nd
-from zarr_sparse.slices import decompose_slices, normalize_slice, slice_size
+from zarr_sparse.slices import slice_size
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from typing import Self
+    from typing import Any, Literal, Self
 
 
 def sparse_equal(a, b, equal_nan: bool) -> bool:
@@ -45,165 +44,6 @@ def sparse_equal(a, b, equal_nan: bool) -> bool:
     return sparse.equal(a, other, equal_nan=equal_nan)
 
 
-class ChunkGrid:
-    """Chunk grid that records slice assignment"""
-
-    def __init__(self, *, shape, dtype, order, fill_value, chunks=None):
-        self._shape = shape
-        self._dtype = dtype
-        self._order = order  # unused, physical arrays are always 1-d for sparse
-        self._fill_value = fill_value
-
-        if chunks is None:
-            chunks = shape
-
-        self._chunks = expand_chunks(chunks, shape)
-        self._bounds = tuple(
-            np.cumulative_sum(c, include_initial=True) for c in self._chunks
-        )
-        grid_shape = tuple(math.ceil(s / max(c)) for s, c in zip(shape, self._chunks))
-        self._data = np.full(grid_shape, dtype=object, fill_value=None)
-
-    @property
-    def shape(self):
-        return self._shape
-
-    @property
-    def ndim(self):
-        return len(self._shape)
-
-    @property
-    def dtype(self):
-        return self._dtype
-
-    @property
-    def order(self):
-        return self._order
-
-    @property
-    def fill_value(self):
-        return self._fill_value
-
-    @property
-    def chunks(self):
-        return self._chunks
-
-    def __repr__(self):
-        shape = self.shape
-        fill_value = self.fill_value
-        chunks = self.chunks
-
-        grid = self._data
-
-        repr_ = f"<ChunkGrid({shape=}, {fill_value=}, {chunks=}>"
-
-        return "\n".join(
-            [
-                repr_,
-                repr(grid),
-            ]
-        )
-
-    def __getitem__(self, key):
-        if any(not isinstance(k, slice) for k in key):
-            return ValueError("indexing is only supported for slices")
-
-        normalized_key = tuple(normalize_slice(k, s) for k, s in zip(key, self.shape))
-        decomposed_slices = decompose_slices(normalized_key, self._bounds)
-        chunk_indices_ = list(c for c, _, _ in decomposed_slices)
-        by_dim = [sorted(set(c)) for c in zip(*chunk_indices_)]
-        new_grid_shape = tuple(len(dim) for dim in by_dim)
-        new_grid = np.full(new_grid_shape, fill_value=None, dtype=object)
-
-        for chunk_indices, local_indexer, _ in decomposed_slices:
-            new_indices = tuple(
-                dim.index(indexer) for indexer, dim in zip(chunk_indices, by_dim)
-            )
-            selected = self._data[chunk_indices]
-
-            new_grid[new_indices] = selected[local_indexer]
-
-        new_shape = tuple(
-            sum(chunksizes)
-            for chunksizes in zip(*(chunk.shape for chunk in new_grid.ravel()))
-        )
-
-        result = type(self)(
-            shape=new_shape,
-            dtype=self.dtype,
-            order=self.order,
-            fill_value=self.fill_value,
-            chunks=None,
-        )
-        result._data = new_grid
-        return result
-
-    def __setitem__(self, key, value):
-        if any(not isinstance(k, slice) for k in key):
-            return ValueError("indexing is only supported for slices")
-
-        selection_sizes = tuple(slice_size(k, size) for k, size in zip(key, self.shape))
-        if selection_sizes != value.shape:
-            raise ValueError("inconsistent assignment")
-
-        normalized_key = tuple(
-            normalize_slice(k, size) for k, size in zip(key, self.shape)
-        )
-
-        if isinstance(value, ChunkGrid):
-            value = value._data.item()
-
-        # decompose into selected chunks and slices into the value
-        # iterate over selected chunks and assign the value subset
-        decomposed_slices = decompose_slices(normalized_key, self._bounds)
-
-        for chunk_indices, _, global_indexer in decomposed_slices:
-            # TODO: fix the bug in `decompose_slice`
-            chunk_shape = tuple(
-                chunks[index] for index, chunks in zip(chunk_indices, self.chunks)
-            )
-            if any(s > c for s, c, in zip(value.shape, chunk_shape)):
-                sliced = value[global_indexer]
-            else:
-                sliced = value
-            if np.any(sliced.shape) == 0:
-                raise RuntimeError(
-                    f"Wrong global indexer {global_indexer} for {value=}"
-                )
-            self._data[chunk_indices] = sliced
-
-    def all_equal(self, other: Any, equal_nan: bool) -> bool:
-        if other.ndim != 0 and (
-            self.shape != other.shape
-            or self.dtype != other.dtype
-            or self.order != other.order
-            or self.fill_value != other.fill_value
-            or self.chunks != other.chunks
-        ):
-            return False
-
-        if other.ndim == 0:
-            to_compare = (
-                (c, other._data.item() if isinstance(other, ChunkGrid) else other)
-                for c in self._data.ravel().tolist()
-            )
-        else:
-            to_compare = zip(self._data.ravel().tolist(), other._data.ravel().tolist())
-
-        return all(sparse_equal(a, b, equal_nan=equal_nan) for a, b in to_compare)
-
-    def get_chunk(self, indexer=None):
-        if indexer is None:
-            if self._data.size != 1:
-                raise ValueError("need to select a chunk for multiple chunk arrays")
-            return self._data.item()
-
-        return self._data[indexer]
-
-    def get_value(self):
-        return combine_nd(self._data)
-
-
 @register_ndbuffer
 class SparseNDBuffer(NDBuffer):
     chunked = True
@@ -221,15 +61,10 @@ class SparseNDBuffer(NDBuffer):
         dtype: npt.DTypeLike,
         order: Literal["C", "F"] = "C",
         fill_value: Any | None = None,
-        chunks=None,
     ) -> Self:
         return cls(
             ChunkGrid(
-                shape=tuple(shape),
-                dtype=dtype,
-                order=order,
-                fill_value=fill_value,
-                chunks=chunks,
+                shape=tuple(shape), dtype=dtype, order=order, fill_value=fill_value
             )
         )
 
@@ -244,7 +79,6 @@ class SparseNDBuffer(NDBuffer):
             dtype=ndarray_like.dtype,
             order="C",
             fill_value=ndarray_like.fill_value,
-            chunks=chunks or getattr(ndarray_like, "chunks", None),
         )
         buffer[(slice(None),) * ndarray_like.ndim] = ndarray_like
 
@@ -264,7 +98,7 @@ class SparseNDBuffer(NDBuffer):
         raise NotImplementedError("can't convert to `numpy`")
 
     def as_ndarray_like(self):
-        return self._data.get_value()
+        return combine_nd(self._data)
 
     def __getitem__(self, key: Any) -> Self:
         return self.__class__(self._data.__getitem__(key))

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -40,6 +40,32 @@ def readjust_bounds(bounds: BoundsType) -> BoundsType:
 
 @dataclass
 class ChunkGrid:
+    """In-memory representation of a general chunk grid
+
+    Parameters
+    ----------
+    dtype : numpy.dtype
+        The dtype of the data
+    order : {"C", "F"}, default: "C"
+        The memory layout for multi-dimensional arrays.
+    fill_value : Any or None, optional
+        The fill value for missing chunks.
+    shape : tuple of int
+        The shape of the logical array.
+    chunk_shape : tuple of int, optional
+        The shape of each chunk. If not given, will be inferred from the first write.
+
+    Attributes
+    ----------
+    shape : tuple of int
+        The shape of the logical array.
+    chunk_shape : tuple of int
+        The shape of each chunk.
+    bounds : mapping of chunk key to tuple of range
+        The bounds for each chunk
+    data : mapping of chunk key to any
+        The stored data.
+    """
 
     dtype: npt.DTypeLike
     order: Literal["C", "F"] = "C"
@@ -106,6 +132,7 @@ class ChunkGrid:
 
     @property
     def offsets(self) -> dict[ChunkKeyType, tuple[int, ...]]:
+        """The offsets of each chunk"""
         return {k: tuple(b.start for b in bounds) for k, bounds in self.bounds.items()}
 
     def __repr__(self) -> str:

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -21,6 +21,21 @@ def readjust_chunk_keys(bounds: dict[ChunkKeyType, Any]) -> dict[ChunkKeyType, A
     }
 
 
+def readjust_bounds(bounds: BoundsType) -> BoundsType:
+    min_chunk_key = tuple(min(x) for x in zip(*bounds.keys()))
+
+    bound_starts = (tuple(b.start for b in bounds_) for bounds_ in bounds.values())
+    min_bound = tuple(min(x) for x in zip(*bound_starts))
+
+    return {
+        tuple(part - offset for part, offset in zip(chunk_key, min_chunk_key)): tuple(
+            range(b.start - offset, b.stop - offset, b.step)
+            for b, offset in zip(bound, min_bound)
+        )
+        for chunk_key, bound in bounds.items()
+    }
+
+
 @dataclass
 class ChunkGrid:
     shape: tuple[int, ...]
@@ -52,11 +67,10 @@ class ChunkGrid:
     def _select_keys(
         self, selected_keys: list[tuple[int, ...]], shape: tuple[int, ...]
     ) -> Self:
-        new = type(self)(shape)
-        new.chunk_shape = self.chunk_shape
+        new = type(self)(shape=shape, chunk_shape=self.chunk_shape)
 
-        new.bounds = readjust_chunk_keys({k: self.bounds[k] for k in selected_keys})
-        new.data = {k: self.data[k] for k in selected_keys}
+        new.bounds = readjust_bounds({k: self.bounds[k] for k in selected_keys})
+        new.data = readjust_chunk_keys({k: self.data[k] for k in selected_keys})
 
         return new
 

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING
 from zarr_sparse.slices import slice_size
 
 if TYPE_CHECKING:
-    from typing import Any, Self
+    from typing import Any, Literal, Self
+
+    import numpy.typing as npt
 
     ChunkKeyType = tuple[int, ...]
     BoundsType = dict[tuple[int, ...], tuple[range, ...]]
@@ -38,9 +40,14 @@ def readjust_bounds(bounds: BoundsType) -> BoundsType:
 
 @dataclass
 class ChunkGrid:
+
+    dtype: npt.DTypeLike
+    order: Literal["C", "F"] = "C"
+    fill_value: Any | None = None
     shape: tuple[int, ...]
 
     chunk_shape: tuple[int, ...] = ()
+
     bounds: BoundsType = field(default_factory=dict, init=False)
     data: dict[tuple[int, ...], Any] = field(default_factory=dict, init=False)
 
@@ -104,5 +111,10 @@ class ChunkGrid:
     def __repr__(self) -> str:
         shape = self.shape
         chunk_shape = self.chunk_shape
+        fill_value = self.fill_value
+        order = self.order
+        dtype = self.dtype
 
-        return f"<ChunkGrid {shape=}, {chunk_shape=}>"
+        return (
+            f"<ChunkGrid {shape=}, {chunk_shape=}, {order=}, {dtype=}, {fill_value=}>"
+        )

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -100,7 +100,13 @@ class ChunkGrid:
     def _select_keys(
         self, selected_keys: list[tuple[int, ...]], shape: tuple[int, ...]
     ) -> Self:
-        new = type(self)(shape=shape, chunk_shape=self.chunk_shape)
+        new = type(self)(
+            shape=shape,
+            chunk_shape=self.chunk_shape,
+            dtype=self.dtype,
+            fill_value=self.fill_value,
+            order=self.order,
+        )
 
         new.bounds = readjust_bounds({k: self.bounds[k] for k in selected_keys})
         new.data = readjust_chunk_keys({k: self.data[k] for k in selected_keys})

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -50,6 +50,26 @@ def readjust_bounds(bounds: BoundsType) -> BoundsType:
     }
 
 
+def recompute_chunk_keys(
+    bounds: BoundsType, data: dict[ChunkKeyType, Any], *, chunk_shape: tuple[int, ...]
+) -> (BoundsType, dict[ChunkKeyType, Any]):
+    if not bounds:
+        # nothing to do
+        return bounds, data
+
+    translations = {
+        chunk_key: tuple(
+            range_.start // size for range_, size in zip(bound, chunk_shape)
+        )
+        for chunk_key, bound in bounds.items()
+    }
+
+    new_bounds = {translations[chunk_key]: bound for chunk_key, bound in bounds.items()}
+    new_data = {translations[chunk_key]: value for chunk_key, value in data.items()}
+
+    return new_bounds, new_data
+
+
 @dataclass
 class ChunkGrid:
     """In-memory representation of a general chunk grid
@@ -95,12 +115,14 @@ class ChunkGrid:
         offsets = tuple(s.start for s in indexers)
         c_shape = tuple(s.stop - s.start for s in indexers)
 
-        if not self.data and offsets != (0,) * len(indexers):
-            # first chunk, must not have an offset
-            raise ValueError("First write must write to the first chunk")
-
-        if not self.chunk_shape:
+        if self.chunk_shape < c_shape:
+            # bigger chunk written, update the chunk shape
             self.chunk_shape = c_shape
+            self.bounds, self.data = recompute_chunk_keys(
+                self.bounds,
+                self.data,
+                chunk_shape=c_shape,
+            )
 
         position = tuple(
             offset // size for offset, size in zip(offsets, self.chunk_shape)

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -67,10 +67,10 @@ class ChunkGrid:
         The stored data.
     """
 
+    shape: tuple[int, ...]
     dtype: npt.DTypeLike
     order: Literal["C", "F"] = "C"
     fill_value: Any | None = None
-    shape: tuple[int, ...]
 
     chunk_shape: tuple[int, ...] = ()
 

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from zarr_sparse.slices import slice_size
+
+if TYPE_CHECKING:
+    import sparse_indexing_container as sic
+
+
+def readjust_chunk_keys(
+    bounds: dict[tuple[int, ...], tuple[range, ...]],
+) -> dict[tuple[int, ...], tuple[range, ...]]:
+    mins = tuple(min(x) for x in zip(*bounds.keys()))
+    return {
+        tuple(part - offset for part, offset in zip(chunk_key, mins)): bound
+        for chunk_key, bound in bounds.items()
+    }
+
+
+@dataclass
+class ChunkGrid:
+    shape: tuple[int, ...]
+
+    chunk_shape: tuple[int, ...] = ()
+    bounds: dict[tuple[int, ...], tuple[range, ...]] = field(
+        default_factory=dict, init=False
+    )
+    data: dict[tuple[int, ...], sic.Container] = field(default_factory=dict, init=False)
+
+    def __setitem__(self, indexers: tuple[slice, ...], value: sic.Container) -> None:
+        offsets = tuple(s.start for s in indexers)
+        c_shape = tuple(s.stop - s.start for s in indexers)
+
+        if not self.data and offsets != (0,) * len(indexers):
+            # first chunk, must not have an offset
+            raise ValueError("First write must write to the first chunk")
+
+        if not self.chunk_shape:
+            self.chunk_shape = c_shape
+
+        position = tuple(
+            offset // size for offset, size in zip(offsets, self.chunk_shape)
+        )
+
+        self.data[position] = value
+        self.bounds[position] = tuple(
+            range(*indexer.indices(size)) for indexer, size in zip(indexers, self.shape)
+        )
+
+    def _select_keys(
+        self, selected_keys: list[tuple[int, ...]], shape: tuple[int, ...]
+    ):
+        new = type(self)(shape)
+        new.chunk_shape = self.chunk_shape
+
+        new.bounds = readjust_chunk_keys({k: self.bounds[k] for k in selected_keys})
+        new.data = {k: self.data[k] for k in selected_keys}
+
+        return new
+
+    def __getitem__(self, indexers: tuple[slice, ...]):
+        # find all keys that intersect with the indexers
+        selected_keys = [
+            key
+            for key, bounds in self.bounds.items()
+            if all(
+                bound.start < indexer.stop and bound.stop > indexer.start
+                for bound, indexer in zip(bounds, indexers)
+            )
+        ]
+        region_size = tuple(
+            slice_size(slice_, size) for slice_, size in zip(indexers, self.shape)
+        )
+        shape = tuple(
+            math.ceil(s / c) * c for s, c in zip(region_size, self.chunk_shape)
+        )
+
+        return self._select_keys(selected_keys, shape)
+
+    @property
+    def ndim(self) -> int:
+        return len(self.shape)
+
+    @property
+    def offsets(self) -> dict[tuple[int, ...], tuple[int, ...]]:
+        return {k: tuple(b.start for b in bounds) for k, bounds in self.bounds.items()}
+
+    def __repr__(self) -> str:
+        shape = self.shape
+        chunk_shape = self.chunk_shape
+
+        return f"<ChunkGrid {shape=}, {chunk_shape=}>"

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -7,12 +7,13 @@ from typing import TYPE_CHECKING
 from zarr_sparse.slices import slice_size
 
 if TYPE_CHECKING:
-    import sparse_indexing_container as sic
+    from typing import Any, Self
+
+    ChunkKeyType = tuple[int, ...]
+    BoundsType = dict[tuple[int, ...], tuple[range, ...]]
 
 
-def readjust_chunk_keys(
-    bounds: dict[tuple[int, ...], tuple[range, ...]],
-) -> dict[tuple[int, ...], tuple[range, ...]]:
+def readjust_chunk_keys(bounds: dict[ChunkKeyType, Any]) -> dict[ChunkKeyType, Any]:
     mins = tuple(min(x) for x in zip(*bounds.keys()))
     return {
         tuple(part - offset for part, offset in zip(chunk_key, mins)): bound
@@ -25,12 +26,10 @@ class ChunkGrid:
     shape: tuple[int, ...]
 
     chunk_shape: tuple[int, ...] = ()
-    bounds: dict[tuple[int, ...], tuple[range, ...]] = field(
-        default_factory=dict, init=False
-    )
-    data: dict[tuple[int, ...], sic.Container] = field(default_factory=dict, init=False)
+    bounds: BoundsType = field(default_factory=dict, init=False)
+    data: dict[tuple[int, ...], Any] = field(default_factory=dict, init=False)
 
-    def __setitem__(self, indexers: tuple[slice, ...], value: sic.Container) -> None:
+    def __setitem__(self, indexers: tuple[slice, ...], value: Any) -> None:
         offsets = tuple(s.start for s in indexers)
         c_shape = tuple(s.stop - s.start for s in indexers)
 
@@ -52,7 +51,7 @@ class ChunkGrid:
 
     def _select_keys(
         self, selected_keys: list[tuple[int, ...]], shape: tuple[int, ...]
-    ):
+    ) -> Self:
         new = type(self)(shape)
         new.chunk_shape = self.chunk_shape
 
@@ -61,7 +60,7 @@ class ChunkGrid:
 
         return new
 
-    def __getitem__(self, indexers: tuple[slice, ...]):
+    def __getitem__(self, indexers: tuple[slice, ...]) -> Self:
         # find all keys that intersect with the indexers
         selected_keys = [
             key

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -105,7 +105,7 @@ class ChunkGrid:
         return len(self.shape)
 
     @property
-    def offsets(self) -> dict[tuple[int, ...], tuple[int, ...]]:
+    def offsets(self) -> dict[ChunkKeyType, tuple[int, ...]]:
         return {k: tuple(b.start for b in bounds) for k, bounds in self.bounds.items()}
 
     def __repr__(self) -> str:

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -4,7 +4,7 @@ import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from zarr_sparse.slices import slice_size
+from zarr_sparse.slices import normalize_slice, slice_size
 
 if TYPE_CHECKING:
     from typing import Any, Literal, Self
@@ -13,6 +13,12 @@ if TYPE_CHECKING:
 
     ChunkKeyType = tuple[int, ...]
     BoundsType = dict[tuple[int, ...], tuple[range, ...]]
+
+
+def normalize_indexers(indexers, shape):
+    return tuple(
+        normalize_slice(indexer, size) for indexer, size in zip(indexers, shape)
+    )
 
 
 def readjust_chunk_keys(bounds: dict[ChunkKeyType, Any]) -> dict[ChunkKeyType, Any]:
@@ -78,6 +84,8 @@ class ChunkGrid:
     data: dict[tuple[int, ...], Any] = field(default_factory=dict, init=False)
 
     def __setitem__(self, indexers: tuple[slice, ...], value: Any) -> None:
+        indexers = normalize_indexers(indexers, self.shape)
+
         offsets = tuple(s.start for s in indexers)
         c_shape = tuple(s.stop - s.start for s in indexers)
 
@@ -114,6 +122,8 @@ class ChunkGrid:
         return new
 
     def __getitem__(self, indexers: tuple[slice, ...]) -> Self:
+        indexers = normalize_indexers(indexers, self.shape)
+
         # find all keys that intersect with the indexers
         selected_keys = [
             key

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -13,9 +13,15 @@ if TYPE_CHECKING:
 
     ChunkKeyType = tuple[int, ...]
     BoundsType = dict[tuple[int, ...], tuple[range, ...]]
+    IndexerType = slice | tuple[slice, ...]
 
 
-def normalize_indexers(indexers, shape):
+def normalize_indexers(
+    indexers: IndexerType, shape: tuple[int, ...]
+) -> tuple[slice, ...]:
+    if not isinstance(indexers, tuple):
+        indexers = (indexers,)
+
     return tuple(
         normalize_slice(indexer, size) for indexer, size in zip(indexers, shape)
     )
@@ -83,7 +89,7 @@ class ChunkGrid:
     bounds: BoundsType = field(default_factory=dict, init=False)
     data: dict[tuple[int, ...], Any] = field(default_factory=dict, init=False)
 
-    def __setitem__(self, indexers: tuple[slice, ...], value: Any) -> None:
+    def __setitem__(self, indexers: IndexerType, value: Any) -> None:
         indexers = normalize_indexers(indexers, self.shape)
 
         offsets = tuple(s.start for s in indexers)
@@ -121,7 +127,7 @@ class ChunkGrid:
 
         return new
 
-    def __getitem__(self, indexers: tuple[slice, ...]) -> Self:
+    def __getitem__(self, indexers: IndexerType) -> Self:
         indexers = normalize_indexers(indexers, self.shape)
 
         # find all keys that intersect with the indexers

--- a/zarr_sparse/chunk_grid.py
+++ b/zarr_sparse/chunk_grid.py
@@ -115,9 +115,13 @@ class ChunkGrid:
         offsets = tuple(s.start for s in indexers)
         c_shape = tuple(s.stop - s.start for s in indexers)
 
-        if self.chunk_shape < c_shape:
-            # bigger chunk written, update the chunk shape
+        if not self.chunk_shape:
             self.chunk_shape = c_shape
+        elif self.chunk_shape != c_shape:
+            # bigger chunk written, update the chunk shape
+            self.chunk_shape = tuple(
+                max(old, new) for old, new in zip(self.chunk_shape, c_shape)
+            )
             self.bounds, self.data = recompute_chunk_keys(
                 self.bounds,
                 self.data,

--- a/zarr_sparse/codec/codec.py
+++ b/zarr_sparse/codec/codec.py
@@ -15,6 +15,7 @@ from zarr.registry import get_pipeline_class, register_codec
 
 from zarr_sparse.buffer import sparse_buffer_prototype
 from zarr_sparse.codec import metadata
+from zarr_sparse.combine import first_value
 from zarr_sparse.comparison import compare_fill_value
 from zarr_sparse.slices import slice_next
 from zarr_sparse.sparse import assemble_array, extract_arrays, sparse_keys
@@ -176,7 +177,7 @@ class SparseArrayCodec(ArrayBytesCodec):
     async def _encode_single(
         self, chunk_array: NDBuffer, chunk_spec: ArraySpec
     ) -> Buffer | None:
-        data = chunk_array._data.get_chunk()
+        data = first_value(chunk_array._data.data)
         if data.nnz == 0 and not chunk_spec.config.write_empty_chunks:
             return None
 

--- a/zarr_sparse/combine.py
+++ b/zarr_sparse/combine.py
@@ -1,13 +1,12 @@
 import itertools
 
-import numpy as np
+
+def first_key(mapping):
+    return next(iter(mapping.keys()))
 
 
-def tiles_by_id(parts):
-    return {
-        np.unravel_index(index, parts.shape): array
-        for index, array in enumerate(parts.flatten())
-    }
+def first_value(mapping):
+    return next(iter(mapping.values()))
 
 
 def until_nth(index):
@@ -32,15 +31,16 @@ def groupby_mapping(mapping, key):
     return ((key, (el for _, el in group)) for key, group in raw_groups)
 
 
-def combine_nd(parts):
-    tiles = tiles_by_id(parts)
-    xp = parts.flat[0].__array_namespace__()
+def combine_nd(tiles):
+    xp = first_value(tiles).__array_namespace__()
+
+    ndim = len(first_key(tiles))
 
     # innermost to outermost
-    for axis in range(parts.ndim - 1, -1, -1):
+    for axis in range(ndim - 1, -1, -1):
         tiles = {
             key: xp.concat(list(arrays), axis=axis)
             for key, arrays in groupby_mapping(tiles, key=until_nth(axis))
         }
 
-    return next(iter(tiles.values()))
+    return first_value(tiles)

--- a/zarr_sparse/combine.py
+++ b/zarr_sparse/combine.py
@@ -23,11 +23,13 @@ def as_item_key(key):
     return wrapper
 
 
+def by_key(it):
+    return it[0]
+
+
 def groupby_mapping(mapping, key):
     wrapped_key = as_item_key(key)
-    raw_groups = itertools.groupby(
-        sorted(mapping.items(), key=wrapped_key), key=wrapped_key
-    )
+    raw_groups = itertools.groupby(sorted(mapping.items(), key=by_key), key=wrapped_key)
     return ((key, (el for _, el in group)) for key, group in raw_groups)
 
 

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -33,14 +33,14 @@ def assert_data_equal(actual, expected):
         pytest.param(dict.fromkeys([(0, 1), (1, 1)]), id="column"),
     ),
 )
-def test_readjust_chunk_keys(chunk_keys):
+def test_readjust_chunk_keys(chunk_keys) -> None:
     actual = chunk_grid.readjust_chunk_keys(chunk_keys)
 
     min_values = tuple(min(v) for v in zip(*actual.keys()))
     assert min_values == (0,) * len(min_values)
 
 
-def test_init():
+def test_init() -> None:
     shape = (10, 10)
     chunk_shape = (5, 5)
     grid = chunk_grid.ChunkGrid(shape=shape, dtype=np.float64, chunk_shape=chunk_shape)
@@ -55,7 +55,7 @@ def test_init():
     assert grid.offsets == {}
 
 
-def test_repr():
+def test_repr() -> None:
     shape = (10, 10)
     chunk_shape = (5, 5)
     grid = chunk_grid.ChunkGrid(shape=shape, dtype=np.int64, chunk_shape=chunk_shape)
@@ -68,7 +68,7 @@ def test_repr():
 
 
 @pytest.mark.parametrize("keys", ([(1,), (2,)], [(0,), (1,)]))
-def test_select_keys(keys):
+def test_select_keys(keys) -> None:
     data = np.arange(10)
 
     grid = chunk_grid.ChunkGrid(shape=(10,), dtype=data.dtype, chunk_shape=(2,))
@@ -88,7 +88,7 @@ def test_select_keys(keys):
     ]
 
 
-def test_setitem_implicit_out_of_order():
+def test_setitem_implicit_out_of_order() -> None:
     data = np.arange(5)
 
     grid = chunk_grid.ChunkGrid(shape=data.shape, dtype=data.dtype)
@@ -112,7 +112,7 @@ def test_setitem_implicit_out_of_order():
     np.testing.assert_equal(grid.data[(1,)], data[2:4])
 
 
-def test_setitem_implicit():
+def test_setitem_implicit() -> None:
     data = np.arange(10 * 8).reshape(10, 8)
 
     grid = chunk_grid.ChunkGrid(shape=(10, 8), dtype=data.dtype)
@@ -140,7 +140,7 @@ def test_setitem_implicit():
     np.testing.assert_equal(grid.data[(1, 1)], data[5:10, 5:8])
 
 
-def test_setitem_explicit():
+def test_setitem_explicit() -> None:
     data = np.arange(10 * 8).reshape(10, 8)
 
     grid = chunk_grid.ChunkGrid(shape=(10, 8), dtype=data.dtype, chunk_shape=(5, 4))
@@ -159,7 +159,7 @@ def test_setitem_explicit():
         (slice(5, 7), {(0,): (range(0, 2, 1),), (1,): (range(2, 3, 1),)}, slice(4, 8)),
     ),
 )
-def test_getitem(indexer, expected_bounds, expected_data_slice):
+def test_getitem(indexer, expected_bounds, expected_data_slice) -> None:
     data = np.arange(7)
     grid = chunk_grid.ChunkGrid(shape=(7,), dtype=data.dtype, chunk_shape=(2,))
 

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -43,7 +43,7 @@ def test_readjust_chunk_keys(chunk_keys):
 def test_init():
     shape = (10, 10)
     chunk_shape = (5, 5)
-    grid = chunk_grid.ChunkGrid(shape=shape, chunk_shape=chunk_shape)
+    grid = chunk_grid.ChunkGrid(shape=shape, dtype=np.float64, chunk_shape=chunk_shape)
 
     assert grid.shape == shape
     assert grid.chunk_shape == chunk_shape
@@ -58,7 +58,7 @@ def test_init():
 def test_repr():
     shape = (10, 10)
     chunk_shape = (5, 5)
-    grid = chunk_grid.ChunkGrid(shape=shape, chunk_shape=chunk_shape)
+    grid = chunk_grid.ChunkGrid(shape=shape, dtype=np.int64, chunk_shape=chunk_shape)
 
     actual = repr(grid)
 
@@ -71,7 +71,7 @@ def test_repr():
 def test_select_keys(keys):
     data = np.arange(10)
 
-    grid = chunk_grid.ChunkGrid(shape=(10,), chunk_shape=(2,))
+    grid = chunk_grid.ChunkGrid(shape=(10,), dtype=data.dtype, chunk_shape=(2,))
 
     grid.bounds = {
         (index,): (range(index * 2, (index + 1) * 2, 1),) for index in range(5)
@@ -91,7 +91,7 @@ def test_select_keys(keys):
 def test_setitem_implicit():
     data = np.arange(10 * 8).reshape(10, 8)
 
-    grid = chunk_grid.ChunkGrid(shape=(10, 8))
+    grid = chunk_grid.ChunkGrid(shape=(10, 8), dtype=data.dtype)
     assert grid.chunk_shape == ()
 
     grid[0:5, 0:5] = data[0:5, 0:5]
@@ -119,7 +119,7 @@ def test_setitem_implicit():
 def test_setitem_explicit():
     data = np.arange(10 * 8).reshape(10, 8)
 
-    grid = chunk_grid.ChunkGrid(shape=(10, 8), chunk_shape=(5, 4))
+    grid = chunk_grid.ChunkGrid(shape=(10, 8), dtype=data.dtype, chunk_shape=(5, 4))
     assert grid.chunk_shape == (5, 4)
 
     grid[0:5, 0:4] = data[0:5, 0:4]
@@ -136,8 +136,8 @@ def test_setitem_explicit():
     ),
 )
 def test_getitem(indexer, expected_bounds, expected_data_slice):
-    grid = chunk_grid.ChunkGrid(shape=(7,), chunk_shape=(2,))
     data = np.arange(7)
+    grid = chunk_grid.ChunkGrid(shape=(7,), dtype=data.dtype, chunk_shape=(2,))
 
     grid.bounds = {
         (0,): (range(0, 2, 1),),

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -1,0 +1,19 @@
+import pytest
+
+from zarr_sparse import chunk_grid
+
+
+@pytest.mark.parametrize(
+    "chunk_keys",
+    (
+        pytest.param(dict.fromkeys((v,) for v in range(1, 3)), id="1d"),
+        pytest.param(dict.fromkeys([(0, 0), (0, 1), (1, 0), (1, 1)]), id="no_change"),
+        pytest.param(dict.fromkeys([(1, 0), (1, 1)]), id="row"),
+        pytest.param(dict.fromkeys([(0, 1), (1, 1)]), id="column"),
+    ),
+)
+def test_readjust_chunk_keys(chunk_keys):
+    actual = chunk_grid.readjust_chunk_keys(chunk_keys)
+
+    min_values = tuple(min(v) for v in zip(*actual.keys()))
+    assert min_values == (0,) * len(min_values)

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -15,6 +15,15 @@ def gen_1d_bounds(start, stop, chunks):
     }
 
 
+def assert_data_equal(actual, expected):
+    __tracebackhide__ = True
+
+    left = {key: value.tolist() for key, value in actual.items()}
+    right = {key: value.tolist() for key, value in expected.items()}
+
+    assert left == right
+
+
 @pytest.mark.parametrize(
     "chunk_keys",
     (
@@ -118,21 +127,32 @@ def test_setitem_explicit():
 
 
 @pytest.mark.parametrize(
-    ["indexer", "expected_bounds"],
+    ["indexer", "expected_bounds", "expected_data_slice"],
     (
-        (slice(0, 5), gen_1d_bounds(0, 6, 2)),
-        (slice(1, 4), gen_1d_bounds(0, 4, 2)),
-        (slice(4, 6), gen_1d_bounds(0, 2, 2)),
-        (slice(5, 7), gen_1d_bounds(0, 4, 2)),
+        (slice(0, 5), gen_1d_bounds(0, 6, 2), slice(0, 6)),
+        (slice(1, 4), gen_1d_bounds(0, 4, 2), slice(0, 4)),
+        (slice(4, 6), gen_1d_bounds(0, 2, 2), slice(4, 6)),
+        (slice(5, 7), {(0,): (range(0, 2, 1),), (1,): (range(2, 3, 1),)}, slice(4, 8)),
     ),
 )
-def test_getitem(indexer, expected_bounds):
+def test_getitem(indexer, expected_bounds, expected_data_slice):
     grid = chunk_grid.ChunkGrid(shape=(7,), chunk_shape=(2,))
     data = np.arange(7)
 
-    grid.bounds = {(idx,): (range(idx * 2, (idx + 1) * 2, 1),) for idx in range(4)}
+    grid.bounds = {
+        (0,): (range(0, 2, 1),),
+        (1,): (range(2, 4, 1),),
+        (2,): (range(4, 6, 1),),
+        (3,): (range(6, 7, 1),),
+    }
     grid.data = {(idx,): data[idx * 2 : (idx + 1) * 2] for idx in range(4)}
 
     actual = grid[(indexer,)]
 
+    expected_data = {
+        (idx,): data[expected_data_slice][idx * 2 : (idx + 1) * 2]
+        for idx in range(len(expected_bounds))
+    }
+
     assert actual.bounds == expected_bounds
+    assert_data_equal(actual.data, expected_data)

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -88,6 +88,30 @@ def test_select_keys(keys):
     ]
 
 
+def test_setitem_implicit_out_of_order():
+    data = np.arange(5)
+
+    grid = chunk_grid.ChunkGrid(shape=data.shape, dtype=data.dtype)
+    assert grid.chunk_shape == ()
+
+    grid[4:5] = data[4:5]
+    step1_bounds = {(4,): (range(4, 5, 1),)}
+    assert grid.chunk_shape == (1,)
+    assert grid.bounds == step1_bounds
+    np.testing.assert_equal(grid.data[(4,)], data[4:5])
+
+    grid[0:2] = data[0:2]
+    step2_bounds = {(0,): (range(0, 2, 1),), (2,): (range(4, 5, 1),)}
+    assert grid.bounds == step2_bounds
+    np.testing.assert_equal(grid.data[(0,)], data[0:2])
+    np.testing.assert_equal(grid.data[(2,)], data[4:5])
+
+    grid[2:4] = data[2:4]
+    step3_bounds = {(1,): (range(2, 4, 1),)}
+    assert grid.bounds == step2_bounds | step3_bounds
+    np.testing.assert_equal(grid.data[(1,)], data[2:4])
+
+
 def test_setitem_implicit():
     data = np.arange(10 * 8).reshape(10, 8)
 

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -1,7 +1,18 @@
+import math
+
 import numpy as np
 import pytest
 
 from zarr_sparse import chunk_grid
+
+
+def gen_1d_bounds(start, stop, chunks):
+    size = stop - start
+    n_chunks = math.ceil(size / chunks)
+    return {
+        (idx,): (range(start + idx * chunks, start + (idx + 1) * chunks, 1),)
+        for idx in range(n_chunks)
+    }
 
 
 @pytest.mark.parametrize(
@@ -62,9 +73,7 @@ def test_select_keys(keys):
 
     indexers = [(slice(index * 2, (index + 1) * 2, 1),) for index, in keys]
 
-    assert len(actual.bounds) == len(keys)
-    assert list(actual.bounds.keys()) == [(0,), (1,)]
-    assert list(actual.bounds.values()) == [(range(*s.indices(10)),) for s, in indexers]
+    assert actual.bounds == gen_1d_bounds(0, 4, 2)
     assert [d.tolist() for d in actual.data.values()] == [
         data[s].tolist() for s in indexers
     ]
@@ -106,3 +115,24 @@ def test_setitem_explicit():
 
     grid[0:5, 0:4] = data[0:5, 0:4]
     assert grid.bounds == {(0, 0): (range(0, 5, 1), range(0, 4, 1))}
+
+
+@pytest.mark.parametrize(
+    ["indexer", "expected_bounds"],
+    (
+        (slice(0, 5), gen_1d_bounds(0, 6, 2)),
+        (slice(1, 4), gen_1d_bounds(0, 4, 2)),
+        (slice(4, 6), gen_1d_bounds(0, 2, 2)),
+        (slice(5, 7), gen_1d_bounds(0, 4, 2)),
+    ),
+)
+def test_getitem(indexer, expected_bounds):
+    grid = chunk_grid.ChunkGrid(shape=(7,), chunk_shape=(2,))
+    data = np.arange(7)
+
+    grid.bounds = {(idx,): (range(idx * 2, (idx + 1) * 2, 1),) for idx in range(4)}
+    grid.data = {(idx,): data[idx * 2 : (idx + 1) * 2] for idx in range(4)}
+
+    actual = grid[(indexer,)]
+
+    assert actual.bounds == expected_bounds

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -68,3 +68,41 @@ def test_select_keys(keys):
     assert [d.tolist() for d in actual.data.values()] == [
         data[s].tolist() for s in indexers
     ]
+
+
+def test_setitem_implicit():
+    data = np.arange(10 * 8).reshape(10, 8)
+
+    grid = chunk_grid.ChunkGrid(shape=(10, 8))
+    assert grid.chunk_shape == ()
+
+    grid[0:5, 0:5] = data[0:5, 0:5]
+    step1_bounds = {(0, 0): (range(0, 5, 1), range(0, 5, 1))}
+    assert grid.chunk_shape == (5, 5)
+    assert grid.bounds == step1_bounds
+    np.testing.assert_equal(grid.data[(0, 0)], data[0:5, 0:5])
+
+    grid[5:10, 0:5] = data[5:10, 0:5]
+    step2_bounds = {(1, 0): (range(5, 10, 1), range(0, 5, 1))}
+    assert grid.bounds == step1_bounds | step2_bounds
+    np.testing.assert_equal(grid.data[(1, 0)], data[5:10, 0:5])
+
+    grid[0:5, 5:8] = data[0:5, 5:8]
+    step3_bounds = {(0, 1): (range(0, 5, 1), range(5, 8, 1))}
+    assert grid.bounds == step1_bounds | step2_bounds | step3_bounds
+    np.testing.assert_equal(grid.data[(0, 1)], data[0:5, 5:8])
+
+    grid[5:10, 5:8] = data[5:10, 5:8]
+    step4_bounds = {(1, 1): (range(5, 10, 1), range(5, 8, 1))}
+    assert grid.bounds == step1_bounds | step2_bounds | step3_bounds | step4_bounds
+    np.testing.assert_equal(grid.data[(1, 1)], data[5:10, 5:8])
+
+
+def test_setitem_explicit():
+    data = np.arange(10 * 8).reshape(10, 8)
+
+    grid = chunk_grid.ChunkGrid(shape=(10, 8), chunk_shape=(5, 4))
+    assert grid.chunk_shape == (5, 4)
+
+    grid[0:5, 0:4] = data[0:5, 0:4]
+    assert grid.bounds == {(0, 0): (range(0, 5, 1), range(0, 4, 1))}

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from zarr_sparse import chunk_grid
@@ -44,3 +45,26 @@ def test_repr():
     assert "ChunkGrid" in actual
     assert f"shape={shape}" in actual
     assert f"chunk_shape={chunk_shape}" in actual
+
+
+@pytest.mark.parametrize("keys", ([(1,), (2,)], [(0,), (1,)]))
+def test_select_keys(keys):
+    data = np.arange(10)
+
+    grid = chunk_grid.ChunkGrid(shape=(10,), chunk_shape=(2,))
+
+    grid.bounds = {
+        (index,): (range(index * 2, (index + 1) * 2, 1),) for index in range(5)
+    }
+    grid.data = {key: data[indexer] for key, indexer in grid.bounds.items()}
+
+    actual = grid._select_keys(keys, shape=(4,))
+
+    indexers = [(slice(index * 2, (index + 1) * 2, 1),) for index, in keys]
+
+    assert len(actual.bounds) == len(keys)
+    assert list(actual.bounds.keys()) == [(0,), (1,)]
+    assert list(actual.bounds.values()) == [(range(*s.indices(10)),) for s, in indexers]
+    assert [d.tolist() for d in actual.data.values()] == [
+        data[s].tolist() for s in indexers
+    ]

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -112,6 +112,23 @@ def test_setitem_implicit_out_of_order() -> None:
     np.testing.assert_equal(grid.data[(1,)], data[2:4])
 
 
+def test_setitem_implicit_2d_partial() -> None:
+    data = np.arange(9).reshape((3, 3))
+    grid = chunk_grid.ChunkGrid(shape=data.shape, dtype=data.dtype)
+
+    grid[2:3, 2:3] = data[2:3, 2:3]
+    assert grid.chunk_shape == (1, 1)
+
+    grid[2:3, 0:2] = data[2:3, 0:2]
+    assert grid.chunk_shape == (1, 2)
+
+    grid[0:2, 2:3] = data[2:3, 4:5]
+    assert grid.chunk_shape == (2, 2)
+
+    grid[0:2, 0:2] = data[0:2, 0:2]
+    assert grid.chunk_shape == (2, 2)
+
+
 def test_setitem_implicit() -> None:
     data = np.arange(10 * 8).reshape(10, 8)
 

--- a/zarr_sparse/tests/test_chunk_grid.py
+++ b/zarr_sparse/tests/test_chunk_grid.py
@@ -17,3 +17,30 @@ def test_readjust_chunk_keys(chunk_keys):
 
     min_values = tuple(min(v) for v in zip(*actual.keys()))
     assert min_values == (0,) * len(min_values)
+
+
+def test_init():
+    shape = (10, 10)
+    chunk_shape = (5, 5)
+    grid = chunk_grid.ChunkGrid(shape=shape, chunk_shape=chunk_shape)
+
+    assert grid.shape == shape
+    assert grid.chunk_shape == chunk_shape
+
+    assert grid.bounds == {}
+    assert grid.data == {}
+
+    assert grid.ndim == 2
+    assert grid.offsets == {}
+
+
+def test_repr():
+    shape = (10, 10)
+    chunk_shape = (5, 5)
+    grid = chunk_grid.ChunkGrid(shape=shape, chunk_shape=chunk_shape)
+
+    actual = repr(grid)
+
+    assert "ChunkGrid" in actual
+    assert f"shape={shape}" in actual
+    assert f"chunk_shape={chunk_shape}" in actual

--- a/zarr_sparse/tests/test_combine.py
+++ b/zarr_sparse/tests/test_combine.py
@@ -5,27 +5,15 @@ from zarr_sparse import combine
 
 
 @pytest.mark.parametrize(
-    ["parts", "expected_ids"],
+    ["mapping", "expected"],
     (
-        (
-            np.array(
-                [[{"x": 1}, {"x": 2}, {"x": 3}], [{"x": 4}, {"x": 5}, {"x": 6}]],
-                dtype=object,
-            ),
-            [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)],
-        ),
-        (
-            np.array(
-                [[[{"x": 1}], [{"x": 2}]], [[{"x": 3}], [{"x": 4}]]], dtype=object
-            ),
-            [(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0)],
-        ),
+        ({"a": 1, "b": 2}, 1),
+        ({1: 3, 0: 1}, 3),
     ),
 )
-def test_tiles_by_id(parts, expected_ids):
-    expected = {id_: {"x": index} for index, id_ in enumerate(expected_ids, start=1)}
+def test_first_value(mapping, expected):
+    actual = combine.first_value(mapping)
 
-    actual = combine.tiles_by_id(parts)
     assert actual == expected
 
 
@@ -157,7 +145,11 @@ def create_grid(shapes, dtype):
 )
 def test_combine_nd(shapes, expected):
     parts = create_grid(shapes, expected.dtype)
+    tiles = {
+        np.unravel_index(index, parts.shape): array
+        for index, array in enumerate(parts.flatten())
+    }
 
-    actual = combine.combine_nd(parts)
+    actual = combine.combine_nd(tiles)
 
     np.testing.assert_equal(actual, expected)

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -1,198 +1,54 @@
 import numpy as np
 import pytest
+import sparse
 
-from zarr_sparse.buffer import ChunkGrid
-from zarr_sparse.comparison import assert_sparse_equal
-from zarr_sparse.tests.generate import create_chunk_slices, create_pydata_coo_array
+from zarr_sparse.buffer import SparseNDBuffer
+from zarr_sparse.chunk_grid import ChunkGrid
 
 
-class TestChunkGrid:
-    @pytest.mark.parametrize(
-        "params",
-        (
-            {"shape": (2, 3), "dtype": "int64", "order": "C", "fill_value": 0},
-            {"shape": (3,), "dtype": "int8", "order": "F", "fill_value": 15},
-            {"shape": (10, 1, 15), "dtype": "float32", "order": "C", "fill_value": 0.0},
-        ),
-    )
-    def test_init(self, params):
-        obj = ChunkGrid(**params)
+class TestNDBuffer:
+    def test_init(self):
+        chunk_grid = ChunkGrid(shape=(4, 4), dtype=np.float64)
 
-        assert {k: getattr(obj, f"_{k}") for k in params} == params
-        np.testing.assert_equal(
-            obj._data,
-            np.full((1,) * len(obj._shape), dtype=object, fill_value=None),
+        buffer = SparseNDBuffer(chunk_grid)
+        assert buffer._data is chunk_grid
+
+    def test_create(self):
+        shape = (4, 4)
+        order = "F"
+        fill_value = 0
+        dtype = np.uint8
+        buffer = SparseNDBuffer.create(
+            shape=shape, dtype=dtype, order=order, fill_value=fill_value
         )
-        expected_chunks = tuple((size,) for size in params["shape"])
-        assert obj._chunks == expected_chunks
 
-    @pytest.mark.parametrize("shape", ((3, 4), (1, 5, 10)))
-    def test_shape(self, shape):
-        obj = ChunkGrid(shape=shape, dtype="float32", order="C", fill_value=0.0)
-
-        assert obj.shape == shape
-
-    @pytest.mark.parametrize("dtype", ("float32", "int64"))
-    def test_dtype(self, dtype):
-        obj = ChunkGrid(shape=(4, 3), dtype=dtype, order="C", fill_value=0.0)
-
-        assert obj.dtype == dtype
-
-    @pytest.mark.parametrize("order", ("C", "F"))
-    def test_order(self, order):
-        obj = ChunkGrid(shape=(4, 3), dtype="int32", order=order, fill_value=0.0)
-
-        assert obj.order == order
-
-    @pytest.mark.parametrize("fill_value", (0, 1))
-    def test_fill_value(self, fill_value):
-        obj = ChunkGrid(shape=(4, 3), dtype="int32", order="C", fill_value=fill_value)
-
-        assert obj.fill_value == fill_value
+        assert buffer._data.shape == shape
+        assert buffer._data.dtype == dtype
+        assert buffer._data.order == order
+        assert buffer._data.fill_value == fill_value
 
     @pytest.mark.parametrize(
-        ["chunks", "expanded"],
+        "array",
         (
-            ((2, 1), ((2, 2), (1, 1, 1))),
-            ((4, 2), ((4,), (2, 1))),
+            sparse.full(shape=(2, 2, 2), dtype="uint8", fill_value=255),
+            sparse.full(shape=(4, 4), dtype="int64", fill_value=0),
+            sparse.full(shape=(8,), dtype="float64", fill_value=np.nan),
         ),
     )
-    def test_chunks(self, chunks, expanded):
-        obj = ChunkGrid(
-            shape=(4, 3),
-            dtype="int32",
-            order="C",
-            fill_value=0,
-            chunks=chunks,
+    def test_from_ndarray_like(self, array):
+        actual = SparseNDBuffer.from_ndarray_like(array)
+
+        assert actual._data.shape == array.shape
+        assert actual._data.dtype == array.dtype
+        assert actual._data.fill_value == array.fill_value or (
+            np.isnan(actual._data.fill_value) and np.isnan(array.fill_value)
         )
 
-        assert obj.chunks == expanded
-
-    @pytest.mark.parametrize(
-        ["dtype", "fill_value"],
-        (
-            ("int64", 0),
-            ("int32", 3),
-            ("float32", 0),
-            ("float64", np.nan),
-        ),
-    )
-    @pytest.mark.parametrize(
-        ["shape", "chunks"],
-        (
-            ((60, 3), (10, 3)),
-            ((100, 100, 100), (20, 50, 50)),
-            ((500,), (5,)),
-        ),
-    )
-    @pytest.mark.parametrize("nnz", (1, 38, 70, 150))
-    def test_setitem_full(self, nnz, shape, chunks, dtype, fill_value):
-        order = "C"
-        sparse_array = create_pydata_coo_array(
-            nnz=nnz, shape=shape, dtype=np.dtype(dtype), fill_value=fill_value
+        chunk_key = (0,) * array.ndim
+        assert actual._data.bounds == {
+            chunk_key: tuple(range(0, n, 1) for n in array.shape)
+        }
+        assert (
+            list(actual._data.data.keys()) == [chunk_key]
+            and actual._data.data[chunk_key] is array
         )
-
-        print(f"input: {sparse_array=}, {chunks=}")
-
-        actual = ChunkGrid(
-            shape=sparse_array.shape,
-            order=order,
-            dtype=sparse_array.dtype,
-            fill_value=sparse_array.fill_value,
-            chunks=chunks,
-        )
-        print(f"ChunkGrid (before assignment):\n{actual}")
-        actual[(slice(None),) * sparse_array.ndim] = sparse_array
-        print(f"ChunkGrid (after assignment):\n{actual}")
-
-        assert_sparse_equal(
-            actual.get_value(),
-            sparse_array,
-        )
-
-    @pytest.mark.parametrize(
-        ["dtype", "fill_value"],
-        (
-            ("int64", 0),
-            ("int32", 3),
-            ("float32", 0),
-            ("float64", np.nan),
-        ),
-    )
-    @pytest.mark.parametrize(
-        ["shape", "chunks"],
-        (
-            ((60, 3), (10, 3)),
-            ((100, 100, 100), (20, 50, 50)),
-            ((500,), (5,)),
-        ),
-    )
-    @pytest.mark.parametrize("nnz", (1, 38, 70, 150))
-    def test_setitem_chunks(self, nnz, shape, chunks, dtype, fill_value):
-        order = "C"
-        sparse_array = create_pydata_coo_array(
-            nnz=nnz, shape=shape, dtype=np.dtype(dtype), fill_value=fill_value
-        )
-
-        chunk_slices = create_chunk_slices(shape, chunks)
-
-        actual = ChunkGrid(
-            shape=sparse_array.shape,
-            order=order,
-            dtype=sparse_array.dtype,
-            fill_value=sparse_array.fill_value,
-            chunks=chunks,
-        )
-
-        for indexer in chunk_slices:
-            actual[indexer] = sparse_array[indexer]
-
-        assert_sparse_equal(
-            actual.get_value(),
-            sparse_array,
-        )
-
-    @pytest.mark.parametrize(
-        ["dtype", "fill_value"],
-        (
-            ("int64", 0),
-            ("int32", 3),
-            ("float32", 0),
-            ("float64", np.nan),
-        ),
-    )
-    @pytest.mark.parametrize(
-        ["shape", "chunks"],
-        (
-            ((60, 3), (10, 3)),
-            ((100, 100, 100), (20, 50, 50)),
-            ((500,), (5,)),
-        ),
-    )
-    @pytest.mark.parametrize("nnz", (1, 38, 70, 150))
-    @pytest.mark.parametrize("chunk_index", (0, 5, -1))
-    def test_getitem(self, nnz, shape, chunks, dtype, fill_value, chunk_index):
-        order = "C"
-        sparse_array = create_pydata_coo_array(
-            nnz=nnz, shape=shape, dtype=np.dtype(dtype), fill_value=fill_value
-        )
-
-        chunk_slices = create_chunk_slices(shape, chunks)
-
-        grid = ChunkGrid(
-            shape=sparse_array.shape,
-            order=order,
-            dtype=sparse_array.dtype,
-            fill_value=sparse_array.fill_value,
-            chunks=chunks,
-        )
-        for index, indexer in enumerate(chunk_slices):
-            chunk_loc = np.unravel_index(index, grid._data.shape)
-
-            grid._data[chunk_loc] = sparse_array[indexer]
-
-        chunk_indexer = chunk_slices[chunk_index]
-        actual = grid[chunk_indexer].get_value()
-        expected = sparse_array[chunk_indexer]
-
-        assert_sparse_equal(actual, expected)

--- a/zarr_sparse/tests/test_ndbuffer.py
+++ b/zarr_sparse/tests/test_ndbuffer.py
@@ -52,3 +52,14 @@ class TestNDBuffer:
             list(actual._data.data.keys()) == [chunk_key]
             and actual._data.data[chunk_key] is array
         )
+
+    def test_as_ndarray_like(self):
+        array = np.arange(10)
+        chunk_grid = ChunkGrid(shape=array.shape, dtype=array.dtype, fill_value=0)
+        chunk_grid[0:5] = array[0:5]
+        chunk_grid[5:10] = array[5:10]
+
+        buffer_ = SparseNDBuffer(chunk_grid)
+
+        actual = buffer_.as_ndarray_like()
+        np.testing.assert_equal(actual, array)

--- a/zarr_sparse/utils.py
+++ b/zarr_sparse/utils.py
@@ -1,0 +1,9 @@
+import functools
+
+
+def as_decorator(func):
+    @functools.wraps(func)
+    def wrapper(obj):
+        return func(obj) or obj
+
+    return wrapper


### PR DESCRIPTION
Initially, the sparse ndbuffer object required information about the buffer.

In this PR, I've reimplemented the chunk grid to use a dict of chunk keys, which are computed using the max chunk size seen per axis (recomputing chunk keys if the chunk shape changes). This means that now this package can work with a vanilla `zarr-python` v3, but the selection of the NDBuffer type is still something to be done.